### PR TITLE
Json like expression

### DIFF
--- a/src/almo.cpp
+++ b/src/almo.cpp
@@ -84,8 +84,8 @@ int main(int argc, char *argv[]){
     auto [meta_data, ast] = almo::parse_md_file(argv[1]);
 
     if (debug) {
-        nlohmann::json ast_json = ast.to_json();
-        std::cout << ast_json.dump(4) << std::endl;
+        json_like::JsonLike ast_json = ast.to_json();
+        ast_json.dump(2);
     }
 
     // コマンドライン引数を meta_data に追加

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -8,6 +8,8 @@
 #include "json.hpp"
 #include "utils.hpp"
 
+#include"json_like.hpp"
+
 namespace almo {
     // to_html, to_config するためにグローバルな設定が保存されるグローバル変数.
     // 格納されるもの:
@@ -28,7 +30,7 @@ namespace almo {
     class ASTNode {
     public:
         // 構文木を json に変換するときに、そのノードの情報を json に追加する. それを頂点とする部分木を json に変換するわけではないので注意.
-        virtual void add_json(nlohmann::json& json) const = 0;
+        virtual void add_json(json_like::JsonLike& json) const = 0;
 
         virtual ~ASTNode() = default;
 
@@ -78,14 +80,14 @@ namespace almo {
         }
 
         // 部分木を json に変換する.
-        nlohmann::json to_json() const {
-            nlohmann::json json;
+        json_like::JsonLike to_json() const {
+            json_like::JsonLike json;
             for (auto child : childs) {
                 if (child->is_leaf()) {
                     std::dynamic_pointer_cast<LeafNode>(child)->add_json(json);
                 }
                 else {
-                    json["childs"].push_back(std::dynamic_pointer_cast<NonLeafNode>(child)->to_json());
+                    json.push_childs(std::dynamic_pointer_cast<NonLeafNode>(child)->to_json());
                 }
             }
             add_json(json);
@@ -110,9 +112,9 @@ namespace almo {
             return "<h" + std::to_string(level) + ">" + join(childs_html) + "</h" + std::to_string(level) + ">";
         }
 
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "Header";
-            json["level"] = level;
+            json["level"] = std::to_string(level);
             json["uuid"] = uuid;
         }
     };
@@ -131,7 +133,7 @@ namespace almo {
             return join(childs_html);
         }
 
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "Block";
             json["uuid"] = uuid;
         }
@@ -153,7 +155,7 @@ namespace almo {
             return content;
         }
 
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "RawText";
             json["content"] = content;
             json["uuid"] = uuid;
@@ -175,7 +177,7 @@ namespace almo {
             return "<div class=\"math-block\"> \\[ \n" + expression + "\n \\] </div>";
         }
 
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "MathBlock";
             json["expression"] = expression;
             json["uuid"] = uuid;
@@ -197,7 +199,7 @@ namespace almo {
         }
 
 
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "InlineMath";
             json["expr"] = expr;
             json["uuid"] = uuid;
@@ -213,7 +215,7 @@ namespace almo {
 
             return "<span class=\"overline\"> <s>" + join(childs_html) + "</s> </span>";
         }
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "InlineOverline";
             json["uuid"] = uuid;
         }
@@ -229,7 +231,7 @@ namespace almo {
         std::string to_html(std::vector<std::string> childs_html) const override {
             return "<span class=\"strong\"> <strong>" + join(childs_html) + "</strong> </span>";
         }
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "InlineStrong";
             json["uuid"] = uuid;
         }
@@ -244,7 +246,7 @@ namespace almo {
         std::string to_html(std::vector<std::string> childs_html) const override {
             return "<span class=\"italic\"> <i>" + join(childs_html) + "</i> </span>";
         }
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "InlineItalic";
             json["uuid"] = uuid;
         }
@@ -259,7 +261,7 @@ namespace almo {
         std::string to_html(std::vector<std::string> childs_html) const override {
             return "<div class=\"plain-text\">" + join(childs_html) + "</span>";
         }
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "PlainText";
             json["uuid"] = uuid;
         }
@@ -285,7 +287,7 @@ namespace almo {
         }
 
 
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "CodeBlock";
             json["code"] = code;
             json["language"] = language;
@@ -303,7 +305,7 @@ namespace almo {
         std::string to_html() const override {
             return "<span class=\"inline-code\"> <code>" + code + "</code> </span>";
         }
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "InlineCodeBlock";
             json["code"] = code;
             json["uuid"] = uuid;
@@ -445,7 +447,7 @@ namespace almo {
             return output;
         }
 
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "Judge";
             json["title"] = title;
             json["sample_in"] = sample_in_path;
@@ -502,7 +504,7 @@ namespace almo {
             return output;
         }
 
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "ExecutableCodeBlock";
             json["code"] = code;
             json["uuid"] = uuid;
@@ -528,9 +530,9 @@ namespace almo {
             return output;
         };
 
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "LoadLib";
-            json["libs"] = libs;
+            json["libs"] = to_string(libs);
             json["uuid"] = uuid;
         }
     };
@@ -547,7 +549,7 @@ namespace almo {
             return "<url> <a href=\"" + url + "\">" + url + "</a> </url>";
         }
 
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "InlineUrl";
             json["url"] = url;
         }
@@ -569,7 +571,7 @@ namespace almo {
             return "<figure>" + output + figcaption + "</figure>";
         }
 
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "InlineImage";
             json["url"] = url;
             json["caption"] = caption;
@@ -589,7 +591,7 @@ namespace almo {
             return "<br>";
         }
 
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "NewLine";
             json["uuid"] = uuid;
         }
@@ -605,7 +607,7 @@ namespace almo {
             return "<ul>" + join(childs_html) + "</ul>";
         }
 
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "ListBlock";
             json["uuid"] = uuid;
         }
@@ -621,7 +623,7 @@ namespace almo {
             return "<ol>" + join(childs_html) + "</ol>";
         }
 
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "EnumerateBlock";
             json["uuid"] = uuid;
         }
@@ -637,7 +639,7 @@ namespace almo {
             return "<li>" + join(childs_html) + "</li>";
         }
 
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "Item";
             json["uuid"] = uuid;
         }
@@ -688,13 +690,13 @@ namespace almo {
             return "dummy";
         }
 
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "Table";
             json["uuid"] = uuid;
             json["n_row"] = n_row;
             json["n_col"] = n_col;
-            json["col_format"] = col_format;
-            json["col_names"] = col_names;
+            json["col_format"] = to_string(col_format);
+            json["col_names"] = to_string(col_names);
         }
 
 
@@ -730,7 +732,7 @@ namespace almo {
             return "<hr>";
         }
 
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "HorizontalLine";
             json["uuid"] = uuid;
         }
@@ -747,7 +749,7 @@ namespace almo {
             return "<blockquote>" + join(childs_html) + "</blockquote>";
         }
 
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "Quote";
             json["uuid"] = uuid;
         }
@@ -764,7 +766,7 @@ namespace almo {
             return "<div class=\"" + div_class + "\">" + join(childs_html) +  "</div>";
         }
 
-        void add_json(nlohmann::json& json) const override {
+        void add_json(json_like::JsonLike& json) const override {
             json["class"] = "DivBlock";
             json["uuid"] = uuid;
         }

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -5,10 +5,8 @@
 #include <utility>
 #include <vector>
 #include <glob.h>
-#include "json.hpp"
+#include "json_like.hpp"
 #include "utils.hpp"
-
-#include"json_like.hpp"
 
 namespace almo {
     // to_html, to_config するためにグローバルな設定が保存されるグローバル変数.

--- a/src/json_like.hpp
+++ b/src/json_like.hpp
@@ -7,7 +7,9 @@
 
 namespace json_like {
 
+// 文字列が改行を含む場合に、適切にインデントをつけて出力する関数
 void output_string_with_indent(std::string s, int current_indent, int indent){
+    // s に改行が含まれているか判定
     bool eoln = false;
     for (char c : s){
         if (c == '\n'){
@@ -15,16 +17,27 @@ void output_string_with_indent(std::string s, int current_indent, int indent){
             break;
         }
     }
+    // s に改行が含まれていないなら、一行しかないのでそのまま出力する
     if (!eoln){
         std::cout << s << '\n';
         return ;
     }
+    // s に改行が含まれている場合は、:::や```で囲まれたブロック内で複数行をまとめて保持している
+    // これをそのまま出力するとインデントが反映されないので、地道にインデントを追加する
+    /*
+    [current_indent]"hoge" :
+    [current_indent]{
+    [current_indent][indent]contents
+    [current_indent]}
+    */
     std::string str_indent(current_indent,' ');
     std::string str_indent_indent(current_indent+indent,' ');
     std::cout << '\n';
     std::cout << str_indent << "{\n";
+    // 直前に改行をしたか
     bool is_pre_eoln = true;
     for (auto c : s){
+        // 直前に改行をした場合は、インデントを追加
         if (is_pre_eoln) std::cout << str_indent_indent;
         is_pre_eoln = false;
         std::cout << c;
@@ -34,19 +47,27 @@ void output_string_with_indent(std::string s, int current_indent, int indent){
 }
 
 struct JsonLike {
+    // json とは違い、同じキーを複数持てる。追加順が保たれる。
     std::vector<std::string> keys, values;
+    // value が JsonLike を持つ場合だけ別処理、必ず push_childs によって追加される。
     std::vector<JsonLike> jsons;
+    // 追加順に、文字列が追加されたか(0)、もしくは JsonLike が追加されたか(1) を保持。
     std::vector<int> key_or_json;
+    // map への追加や、既存の json への key を指定した value の追加と同じ記法がで追加できるようにした。
     std::string &operator[](std::string str_idx){
         key_or_json.push_back(0);
         keys.push_back(str_idx);
         values.push_back("");
         return values.back();
     }
+    // JsonLike を追加する場合はこちらから
     void push_childs(JsonLike json){
         key_or_json.push_back(1);
         jsons.push_back(json);
     }
+    // cout に JsonLike が持っている情報を書き出す
+    // indent は一段下がると何スペース分下がるかを表す。 
+    // current_indent は何スペース下がった位置が 0 インデントの位置かを表す（再帰するため相対的な行上の位置が必要）。
     void dump(int indent = 2, int current_indent = 0){
         int size = key_or_json.size();
         std::string str_indent(current_indent,' ');
@@ -55,11 +76,13 @@ struct JsonLike {
         int keys_id = 0, jsons_id = 0;
         for (int i = 0; i < size; i++){
             if (key_or_json[i] == 0){
+                // 文字列の場合は、改行のあるなしで出力形式が変わる
                 std::cout << str_indent_indent << "\"" << keys[keys_id] << "\": ";
                 output_string_with_indent(values[keys_id],current_indent+indent,indent);
                 keys_id++;
             }
             else {
+                // JsonLike の場合は相対的なインデントを更新して再帰を投げる
                 std::cout << str_indent_indent << "\"childs\":\n";
                 jsons[jsons_id].dump(indent,current_indent+indent);
                 jsons_id++;

--- a/src/json_like.hpp
+++ b/src/json_like.hpp
@@ -1,0 +1,72 @@
+#include<vector>
+#include<string>
+#include<utility>
+#include<iostream>
+#include<string_view>
+#include<ranges>
+
+namespace json_like {
+
+void output_string_with_indent(std::string s, int current_indent, int indent){
+    bool eoln = false;
+    for (char c : s){
+        if (c == '\n'){
+            eoln = true;
+            break;
+        }
+    }
+    if (!eoln){
+        std::cout << s << '\n';
+        return ;
+    }
+    std::string str_indent(current_indent,' ');
+    std::string str_indent_indent(current_indent+indent,' ');
+    std::cout << '\n';
+    std::cout << str_indent << "{\n";
+    bool is_pre_eoln = true;
+    for (auto c : s){
+        if (is_pre_eoln) std::cout << str_indent_indent;
+        is_pre_eoln = false;
+        std::cout << c;
+        if (c == '\n') is_pre_eoln = true;
+    }
+    std::cout << str_indent << "}\n";
+}
+
+struct JsonLike {
+    std::vector<std::string> keys, values;
+    std::vector<JsonLike> jsons;
+    std::vector<int> key_or_json;
+    std::string &operator[](std::string str_idx){
+        key_or_json.push_back(0);
+        keys.push_back(str_idx);
+        values.push_back("");
+        return values.back();
+    }
+    void push_childs(JsonLike json){
+        key_or_json.push_back(1);
+        jsons.push_back(json);
+    }
+    void dump(int indent = 2, int current_indent = 0){
+        int size = key_or_json.size();
+        std::string str_indent(current_indent,' ');
+        std::string str_indent_indent(indent+current_indent,' ');
+        std::cout << str_indent << "{\n";
+        int keys_id = 0, jsons_id = 0;
+        for (int i = 0; i < size; i++){
+            if (key_or_json[i] == 0){
+                std::cout << str_indent_indent << "\"" << keys[keys_id] << "\": ";
+                output_string_with_indent(values[keys_id],current_indent+indent,indent);
+                keys_id++;
+            }
+            else {
+                std::cout << str_indent_indent << "\"childs\":\n";
+                jsons[jsons_id].dump(indent,current_indent+indent);
+                jsons_id++;
+            }
+        }
+        std::cout << str_indent << "}\n";
+    }
+};
+
+} // namespace json_like

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -261,3 +261,23 @@ std::string _apply_alias(std::string s, std::map<std::string, std::string> alias
     return s;
 }
 
+
+std::string to_string(const std::vector<int> &vec){
+    std::string str_vec = "{ ";
+    for (int i = 0; auto t : vec){
+        if (i++ != 0) str_vec += ", ";
+        str_vec += std::to_string(t);
+    }
+    str_vec += " }";
+    return str_vec;
+}
+
+std::string to_string(const std::vector<std::string> &vec){
+    std::string str_vec = "{ ";
+    for (int i = 0; auto t : vec){
+        if (i++ != 0) str_vec += ", ";
+        str_vec += t;
+    }
+    str_vec += " }";
+    return str_vec;
+}

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <map>
 #include <iostream>
+#include <cstring>
 
 // 文字列の vector を 結合する。第二引数はOptionalで区切り文字。デフォルトは空
 std::string join(std::vector<std::string> v, std::string sep = "") {


### PR DESCRIPTION
`json.hpp` から脱却した :tada:

そもそも json に追加するときにキーの重複があってうまく表示できていなかった。
この変更で、キーの重複を許し、キーの追加順（つまり、概ね書かれている順）に表示されるようになった。