### PR TITLE
リリースの整備

### DIFF
--- a/.github/workflows/dockerhub.yaml
+++ b/.github/workflows/dockerhub.yaml
@@ -1,0 +1,26 @@
+name: Build and push Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/almo:latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+name: Release for all platforms
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build_and_upload:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-14]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build
+        run: sh build.sh
+
+      - name: Upload Release
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: build/main
+          asset_name: ${{ matrix.os }}
+          asset_content_type: application/octet-stream 
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:latest
+
+RUN apk add --no-cache g++
+
+WORKDIR /app
+
+COPY . .
+
+RUN sh build.sh
+
+ENTRYPOINT [ "./docker-entrypoint.sh" ]

--- a/build.sh
+++ b/build.sh
@@ -26,6 +26,4 @@ done
 
 g++ -std=c++20 "$build_dir"almo.cpp -o "$build_dir"almo 
 
-mv "$build_dir"almo .
-
 echo "ビルドが完了しました。"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /app/build/almo "$@"


### PR DESCRIPTION
fix #66
リリース作成時に Docker Hubにイメージをアップロードし、複数プラットフォーム向けのバイナリも自動でアップロードされるようにした