### PR TITLE
子ノードが存在しない場合に json のフォーマットが崩れるバグを修正

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -25,7 +25,7 @@ done
 
 
 
-g++ -std=c++20 "$build_dir"almo.cpp -o "$build_dir"almo 
+g++ -std=c++23 "$build_dir"almo.cpp -o "$build_dir"almo 
 
 if [ $? -ne 0 ]; then
     echo "ビルドに失敗しました。"

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 #include <glob.h>
+#include <ranges>
 #include "utils.hpp"
 
 namespace almo {
@@ -142,11 +143,9 @@ namespace almo {
             }
 
             json += "\"childs\":[";
-            for (auto child : childs) {
-                json += child->to_json() + ",";
+            for (auto c : childs | std::views::transform([](auto child){ return child->to_json(); }) | std::views::join_with(',')){
+                json += c;
             }
-            // 最後のカンマを削除する
-            json = json.substr(0, json.length() - 1);
             json += "]}";
             return json;
         }


### PR DESCRIPTION
fix #93

childs を `,` で分割して並べる文字列を、 `std::views::join_with()` を用いた実装に変更した。