### PR TITLE
インターフェースの整備

### DIFF
--- a/src/almo.cpp
+++ b/src/almo.cpp
@@ -132,6 +132,10 @@ void debug_json(std::string ir_json, std::map<std::string, std::string> meta_dat
     std::cout << output << std::endl;
 }
 
+void debug_graph(almo::Block ast){
+    std::cout << ast.to_dot(true) << std::endl;
+}
+
 
 
 int main(int argc, char* argv[]) {
@@ -155,13 +159,8 @@ int main(int argc, char* argv[]) {
     }
 
     if (config.plot_graph) {
-        std::string graph = ast.to_dot();
-        std::cout << "digraph g {" << std::endl;
-        std::cout << "    graph [" << std::endl;
-        std::cout << "        labelloc=\"t\";" << std::endl;
-        std::cout << "        ];" << std::endl;
-        std::cout << graph << std::endl;
-        std::cout << "}" << std::endl;
+        debug_graph(ast);
+        return 0;
     }
 
     almo::meta_data = meta_data;

--- a/src/almo.cpp
+++ b/src/almo.cpp
@@ -163,7 +163,7 @@ int main(int argc, char* argv[]) {
         return 0;
     }
 
-    almo::meta_data = meta_data;
+
     std::string result = almo::render(ast, meta_data);
 
     if (config.out_path == "__stdout__") {

--- a/src/almo.cpp
+++ b/src/almo.cpp
@@ -34,6 +34,7 @@ public:
                     throw InvalidCommandLineArgumentsError("不正なコマンドライン引数です。 -h オプションでヘルプを確認してください。");
                     exit(1);
                 }
+                
                 switch (argv[i][1]) {
                     case 'o':
                         out_path = argv[i + 1];
@@ -116,6 +117,23 @@ public:
     }
 };
 
+
+void debug_json(std::string ir_json, std::map<std::string, std::string> meta_data) {
+    std::string meta_dump = "{\n";
+    for (auto& [key, value] : meta_data) {
+        meta_dump += "   \"" + key + "\": \"" + escape(value) + "\",";
+    }
+    meta_dump = meta_dump.substr(0, meta_dump.length() - 1);
+    meta_dump += "} \n";
+    std::string output = "{\n"
+        "\"meta\": " + meta_dump + ",\n"
+        "\"ir\": " + ir_json + "\n"
+        "}\n";
+    std::cout << output << std::endl;
+}
+
+
+
 int main(int argc, char* argv[]) {
     Config config;
     config.parse_arguments(argc, argv);
@@ -132,18 +150,8 @@ int main(int argc, char* argv[]) {
     meta_data["syntax_theme"] = config.syntax_theme;
 
     if (config.debug) {
-        std::string ir = ast.to_json();
-        std::string meta_dump = "{\n";
-        for (auto& [key, value] : meta_data) {
-            meta_dump += "   \"" + key + "\": \"" + escape(value) + "\",";
-        }
-        meta_dump = meta_dump.substr(0, meta_dump.length() - 1);
-        meta_dump += "} \n";
-        std::string output = "{\n"
-            "\"meta\": " + meta_dump + ",\n"
-            "\"ir\": " + ir + "\n"
-            "}\n";
-        std::cout << output << std::endl;
+        std::string ir_json = ast.to_json();
+        debug_json(ir_json, meta_data);
     }
 
     if (config.plot_graph) {

--- a/src/almo.cpp
+++ b/src/almo.cpp
@@ -5,36 +5,8 @@
 #include <string>
 #include "utils.hpp"
 
-void help(bool err) {
-    if (err) {
-        std::cerr << "使用法: almo <入力> [オプション]" << std::endl;
-        std::cerr << "オプション:" << std::endl;
-        std::cerr << "  -o <出力>     出力ファイル名を指定します。 指定しない場合標準出力に出力されます。" << std::endl;
-        std::cerr << "  -b <テンプレート> テンプレートファイルを指定します。 " << std::endl;
-        std::cerr << "  -t <テーマ>   テーマを指定します。デフォルトは light です。" << std::endl;
-        std::cerr << "  -c <CSS>      CSSファイルを指定します。デフォルトは テーマに付属するものが使用されます。" << std::endl;
-        std::cerr << "  -e <テーマ>   エディタのテーマを指定します。デフォルトは  です。" << std::endl;
-        std::cerr << "  -d            デバッグモードで実行します。" << std::endl;
-        std::cerr << "  -g            構文木をdot言語として出力します。" << std::endl;
-        std::cerr << "  -h            ヘルプを表示します。" << std::endl;
-    }
-    else {
-        std::cout << "使用法: almo <入力> [オプション]" << std::endl;
-        std::cout << "オプション:" << std::endl;
-        std::cout << "  -o <出力>     出力ファイル名を指定します。 指定しない場合標準出力に出力されます。" << std::endl;
-        std::cout << "  -b <テンプレート> テンプレートファイルを指定します。 " << std::endl;
-        std::cout << "  -t <テーマ>   テーマを指定します。デフォルトは light です。" << std::endl;
-        std::cout << "  -c <CSS>      CSSファイルを指定します。デフォルトは テーマに付属するものが使用されます。" << std::endl;
-        std::cout << "  -e <テーマ>   エディタのテーマを指定します。デフォルトは  です。" << std::endl;
-        std::cout << "  -d            デバッグモードで実行します。" << std::endl;
-        std::cout << "  -g            構文木をdot言語として出力します。" << std::endl;
-        std::cout << "  -h            ヘルプを表示します。" << std::endl;
-    }
-}
-
-
-int main(int argc, char* argv[]) {
-    // コマンドライン引数のデフォルト値を設定
+class Config {
+public:
     std::string template_file = "__default__";
     std::string theme = "light";
     std::string css_setting = "__default__";
@@ -44,118 +16,137 @@ int main(int argc, char* argv[]) {
     bool plot_graph = false;
     std::string out_path = "__stdout__";
 
+    void parse_arguments(int argc, char* argv[]) {
+        if (argc < 2) {
+            std::cerr << "コマンドライン引数が不足しています。" << std::endl;
+            show_help(true);
+            exit(1);
+        }
 
-    if (argc < 2) {
-        std::cerr << "コマンドライン引数が不足しています。" << std::endl;
-        help(true);
-        exit(1);
+        if (argc == 2 && std::string(argv[1]) == "-h") {
+            show_help(false);
+            exit(0);
+        }
+
+        for (int i = 2; i < argc; i++) {
+            if (argv[i][0] == '-') {
+                if (std::string(argv[i]).length() > 2) {
+                    throw InvalidCommandLineArgumentsError("不正なコマンドライン引数です。 -h オプションでヘルプを確認してください。");
+                    exit(1);
+                }
+                switch (argv[i][1]) {
+                    case 'o':
+                        out_path = argv[i + 1];
+                        i++;
+                        break;
+                    case 'b':
+                        template_file = argv[i + 1];
+                        i++;
+                        break;
+                    case 't':
+                        theme = argv[i + 1];
+                        i++;
+                        break;
+                    case 'c':
+                        css_setting = argv[i + 1];
+                        i++;
+                        break;
+                    case 'd':
+                        debug = true;
+                        break;
+                    case 'e':
+                        editor_theme = argv[i + 1];
+                        i++;
+                        break;
+                    case 's':
+                        syntax_theme = argv[i + 1];
+                        i++;
+                        break;
+                    case 'g':
+                        plot_graph = true;
+                        break;
+                    case 'h':
+                        throw InvalidCommandLineArgumentsError("不正なコマンドライン引数です。 -h オプションと他のオプションは同時に指定できません。");
+                    default:
+                        std::cerr << "不正なコマンドライン引数です。 -h オプションでヘルプを確認してください。" << std::endl;
+                        exit(1);
+                }
+            }
+        }
+
+        apply_theme_defaults();
     }
 
-    if (argc == 2 && argv[1][0] == '-' && argv[1][1] == 'h') {
-        help(false);
-        exit(0);
-    }
-
-    for (int i = 2; i < argc; i++) {
-        if (argv[i][0] == '-') {
-            if (strlen(argv[i]) > 3) {
-                throw InvalidCommandLineArgumentsError("不正なコマンドライン引数です。 -h オプションでヘルプを確認してください。");
-                exit(1);
+    void apply_theme_defaults() {
+        if (theme == "light") {
+            if (editor_theme == "__default__") {
+                editor_theme = "ace/theme/chrome";
             }
-            if (argv[i][1] == 'o') {
-                out_path = argv[i + 1];
+            if (syntax_theme == "__default__") {
+                syntax_theme = "github.min";
             }
-            else if (argv[i][1] == 'b') {
-                template_file = argv[i + 1];
+            if (css_setting == "__default__") {
+                css_setting = "light";
             }
-            else if (argv[i][1] == 't') {
-                theme = argv[i + 1];
+        } else if (theme == "dark") {
+            if (editor_theme == "__default__") {
+                editor_theme = "ace/theme/monokai";
             }
-            else if (argv[i][1] == 'c') {
-                css_setting = argv[i + 1];
+            if (syntax_theme == "__default__") {
+                syntax_theme = "monokai.min";
             }
-            else if (argv[i][1] == 'd') {
-                debug = true;
-            }
-            else if (argv[i][1] == 'e') {
-                editor_theme = argv[i + 1];
-            }
-            else if (argv[i][1] == 's') {
-                syntax_theme = argv[i + 1];
-            }
-            else if (argv[i][1] == 'g') {
-                plot_graph = true;
-            }
-            else if (argv[i][1] == 'h') {
-                throw InvalidCommandLineArgumentsError("不正なコマンドライン引数です。 -h オプションと他のオプションは同時に指定できません。");
-            }
-            else {
-                std::cerr << "不正なコマンドライン引数です。 -h オプションでヘルプを確認してください。" << std::endl;
-                exit(1);
+            if (css_setting == "__default__") {
+                css_setting = "dark";
             }
         }
     }
 
-
-    // もし theme が dark であれば、 editor_theme と syntax_theme がデフォルトの場合対応したものにしておく
-    if (theme == "light") {
-        if (editor_theme == "__default__") {
-            editor_theme = "ace/theme/chrome";
-        }
-
-        if (syntax_theme == "__default__") {
-            syntax_theme = "github.min";
-        }
-
-        if (css_setting == "__default__") {
-            css_setting = "light";
-        }
+    void show_help(bool err) const {
+        std::ostream& out = err ? std::cerr : std::cout;
+        out << "使用法: almo <入力> [オプション]" << std::endl;
+        out << "オプション:" << std::endl;
+        out << "  -o <出力>     出力ファイル名を指定します。 指定しない場合標準出力に出力されます。" << std::endl;
+        out << "  -b <テンプレート> テンプレートファイルを指定します。 " << std::endl;
+        out << "  -t <テーマ>   テーマを指定します。デフォルトは light です。" << std::endl;
+        out << "  -c <CSS>      CSSファイルを指定します。デフォルトは テーマに付属するものが使用されます。" << std::endl;
+        out << "  -e <テーマ>   エディタのテーマを指定します。デフォルトは  です。" << std::endl;
+        out << "  -d            デバッグモードで実行します。" << std::endl;
+        out << "  -g            構文木をdot言語として出力します。" << std::endl;
+        out << "  -h            ヘルプを表示します。" << std::endl;
     }
-    else if (theme == "dark") {
-        if (editor_theme == "__default__") {
-            editor_theme = "ace/theme/monokai";
-        }
+};
 
-        if (syntax_theme == "__default__") {
-            syntax_theme = "monokai.min";
-        }
-
-        if (css_setting == "__default__") {
-            css_setting = "dark";
-        }
-    }
+int main(int argc, char* argv[]) {
+    Config config;
+    config.parse_arguments(argc, argv);
 
     // パース
     auto [meta_data, ast] = almo::parse_md_file(argv[1]);
 
     // コマンドライン引数を meta_data に追加
-    meta_data["template_file"] = template_file;
-    meta_data["theme"] = theme;
-    meta_data["out_path"] = out_path;
-    meta_data["css_setting"] = css_setting;
-    meta_data["editor_theme"] = editor_theme;
-    meta_data["syntax_theme"] = syntax_theme;
+    meta_data["template_file"] = config.template_file;
+    meta_data["theme"] = config.theme;
+    meta_data["out_path"] = config.out_path;
+    meta_data["css_setting"] = config.css_setting;
+    meta_data["editor_theme"] = config.editor_theme;
+    meta_data["syntax_theme"] = config.syntax_theme;
 
-
-    if (debug) {
+    if (config.debug) {
         std::string ir = ast.to_json();
         std::string meta_dump = "{\n";
-        for (auto [key, value] : meta_data) {
+        for (auto& [key, value] : meta_data) {
             meta_dump += "   \"" + key + "\": \"" + escape(value) + "\",";
         }
-        // 最後のカンマを削除
         meta_dump = meta_dump.substr(0, meta_dump.length() - 1);
         meta_dump += "} \n";
         std::string output = "{\n"
             "\"meta\": " + meta_dump + ",\n"
             "\"ir\": " + ir + "\n"
             "}\n";
-
-
         std::cout << output << std::endl;
     }
 
-    if (plot_graph) {
+    if (config.plot_graph) {
         std::string graph = ast.to_dot();
         std::cout << "digraph g {" << std::endl;
         std::cout << "    graph [" << std::endl;
@@ -165,17 +156,13 @@ int main(int argc, char* argv[]) {
         std::cout << "}" << std::endl;
     }
 
-
-
     almo::meta_data = meta_data;
-
     std::string result = almo::render(ast, meta_data);
 
-    if (out_path == "__stdout__") {
+    if (config.out_path == "__stdout__") {
         std::cout << result << std::endl;
-    }
-    else {
-        std::ofstream ofs(out_path);
+    } else {
+        std::ofstream ofs(config.out_path);
         ofs << result << std::endl;
     }
 

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -151,7 +151,7 @@ namespace almo {
         }
 
         // 部分木を dot 言語に変換する.
-        virtual std::string to_dot() const {
+        virtual std::string to_dot(bool is_root = false) const {
             std::map<std::string, std::string> properties = get_properties();
 
             std::string node = get_uuid();
@@ -182,7 +182,13 @@ namespace almo {
                 edges += node + ":f" + std::to_string(edges.length()) + " -> " + child->get_uuid() + "\n";
             }
 
-            return node + "[label=\"" + label_header + label + "\", shape=\"record\"]\n" + childs_dot + edges;
+            std::string content =  node + "[label=\"" + label_header + label + "\", shape=\"record\"]\n" + childs_dot + edges;
+
+            if (is_root) {
+                return "digraph G {\n graph [labelloc=\"t\"; \n ]\n" + content + "}";
+            } else {
+                return content;
+            }
         }
 
     };

--- a/src/parse.hpp
+++ b/src/parse.hpp
@@ -765,31 +765,10 @@ namespace almo {
     };
 
 
-    // mdファイルの内容から
-    // メタデータ (std::map<std::string, std::string>) と
-    // 抽象構文木の根 (Block) のペアを返す。
-    std::pair<std::map<std::string, std::string>, Block> parse(std::vector<std::string> content) {
-        std::vector<std::pair<std::string, std::string>> meta_data;
-        int meta_data_end = 0;
-
-        if (!content.empty() && content[0] == "---") {
-            int index = 1;
-            while (index < (int)content.size() && content[index] != "---") {
-                std::string key = std::regex_replace(content[index], std::regex("(.*):\\s(.*)"), "$1");
-                std::string data = std::regex_replace(content[index], std::regex("(.*):\\s(.*)"), "$2");
-                meta_data.emplace_back(key, data);
-                index++;
-            }
-            meta_data_end = index + 1;
-        }
-
-        // メタデータ以降の行を取り出し
-        std::vector<std::string> md_lines;
-        for (int i = meta_data_end; i < (int)content.size(); i++) {
-            md_lines.push_back(content[i]);
-        }
-
-        std::string md_str = join(md_lines, "\n");
+    // md ファイルの中身 (frot YAML を含まない)
+    // を受け取って、前処理 ([コメントの削除, ])　を行う
+    std::vector<std::string> preprocess(std::vector<std::string> content) {
+        std::string content_join = join(content, "\n");
 
         // コメントを削除
         auto remove_comment = [](std::string text) {
@@ -802,10 +781,49 @@ namespace almo {
         };
 
         for (auto hook : hooks) {
-            md_str = hook(md_str);
+            content_join = hook(content_join);
         }
 
-        md_lines = split(md_str, "\n");
+        content = split(content_join, "\n");
+
+        return content;
+    }
+
+    // md ファイルの中身 (front YAML) 
+    // を受け取って、 front YAML をパースした結果と残りの md ファイルの開始位置を返す
+    // TODO: きちんとした YAML パーサを使うようにする。
+    std::pair<std::vector<std::pair<std::string, std::string>>, int> parse_front(std::vector<std::string> content) {
+        std::vector<std::pair<std::string, std::string>> front_yaml;
+        int front_yaml_end = 0;
+
+        if (!content.empty() && content[0] == "---") {
+            int index = 1;
+            while (index < (int)content.size() && content[index] != "---") {
+                std::string key = std::regex_replace(content[index], std::regex("(.*):\\s(.*)"), "$1");
+                std::string data = std::regex_replace(content[index], std::regex("(.*):\\s(.*)"), "$2");
+                front_yaml.emplace_back(key, data);
+                index++;
+            }
+            front_yaml_end = index + 1;
+        }
+
+        return { front_yaml, front_yaml_end };
+    }
+
+    // mdファイルの内容から
+    // メタデータ (std::map<std::string, std::string>) と
+    // 抽象構文木の根 (Block) のペアを返す。
+    std::pair<std::map<std::string, std::string>, Block> parse(std::vector<std::string> content) {
+        auto [meta_data, meta_data_end] = parse_front(content);
+
+        // メタデータ以降の行を取り出し
+        std::vector<std::string> md_lines;
+        for (int i = meta_data_end; i < (int)content.size(); i++) {
+            md_lines.push_back(content[i]);
+        }
+
+        // 前処理
+        md_lines = preprocess(md_lines);
 
         // パース
         BlockParser parser = BlockParser();

--- a/src/parse.hpp
+++ b/src/parse.hpp
@@ -764,20 +764,19 @@ namespace almo {
         }
     };
 
-    // mdファイルのパスから
+
+    // mdファイルの内容から
     // メタデータ (std::map<std::string, std::string>) と
     // 抽象構文木の根 (Block) のペアを返す。
-    std::pair<std::map<std::string, std::string>, Block> parse_md_file(std::string path) {
-        std::vector<std::string> lines = read_file(path);
-
+    std::pair<std::map<std::string, std::string>, Block> parse(std::vector<std::string> content) {
         std::vector<std::pair<std::string, std::string>> meta_data;
         int meta_data_end = 0;
 
-        if (!lines.empty() && lines[0] == "---") {
+        if (!content.empty() && content[0] == "---") {
             int index = 1;
-            while (index < (int)lines.size() && lines[index] != "---") {
-                std::string key = std::regex_replace(lines[index], std::regex("(.*):\\s(.*)"), "$1");
-                std::string data = std::regex_replace(lines[index], std::regex("(.*):\\s(.*)"), "$2");
+            while (index < (int)content.size() && content[index] != "---") {
+                std::string key = std::regex_replace(content[index], std::regex("(.*):\\s(.*)"), "$1");
+                std::string data = std::regex_replace(content[index], std::regex("(.*):\\s(.*)"), "$2");
                 meta_data.emplace_back(key, data);
                 index++;
             }
@@ -786,8 +785,8 @@ namespace almo {
 
         // メタデータ以降の行を取り出し
         std::vector<std::string> md_lines;
-        for (int i = meta_data_end; i < (int)lines.size(); i++) {
-            md_lines.push_back(lines[i]);
+        for (int i = meta_data_end; i < (int)content.size(); i++) {
+            md_lines.push_back(content[i]);
         }
 
         std::string md_str = join(md_lines, "\n");
@@ -833,5 +832,14 @@ namespace almo {
         }
 
         return { meta_data_map,  ast };
+    }
+
+
+    // mdファイルのパスから
+    // メタデータ (std::map<std::string, std::string>) と
+    // 抽象構文木の根 (Block) のペアを返す。
+    std::pair<std::map<std::string, std::string>, Block> parse_md_file(std::string path) {
+        std::vector<std::string> content = read_file(path);
+        return parse(content);
     }
 }

--- a/src/render.hpp
+++ b/src/render.hpp
@@ -87,7 +87,7 @@ namespace almo {
     }
 
     std::string render(Block ast, std::map<std::string, std::string> meta_data) {
-        std::string content = ast.render();
+        std::string content = ast.render(meta_data);
 
         std::string html_template = load_html_template(meta_data["template_file"], meta_data["css_setting"]);
     

--- a/src/render.hpp
+++ b/src/render.hpp
@@ -11,20 +11,20 @@
 #include "utils.hpp"
 
 namespace almo {
-    std::string LIGHT_THEME =
+    std::string LIGHT_THEME = {
             #include "light.css"
-        ;
-    std::string DARK_THEME =
+    };
+    std::string DARK_THEME = {
             #include "dark.css"
-        ;
+    };
 
-    std::string RUNNER =
+    std::string RUNNER = {
             #include "runner.js"
-        ;
+    };
 
-    std::string TEMPLATE =
+    std::string TEMPLATE = {
             #include "template.html"
-        ;
+    };
 
 
     


### PR DESCRIPTION
fix #100 

今後外から呼び出しを行うことを考えて、多くのインターフェースを整えた。

これで新たに

1. front YAML はあらかじめパースしておいて、残りの部分だけパースさせる
2. コマンドライン引数はあらかじめパースしておいて、パースさせる

などができるようになる。
