### PR TITLE
AST のノードの付け替えを実装

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "utils.hpp"
 #include "interfaces/ast.hpp"
+#include "utils.hpp"
 
 namespace almo {
 
 struct uuid_gen_ {
-    int operator()(){
+    int operator()() {
         static int uuid = 0;
         return uuid++;
     }
@@ -24,14 +24,15 @@ std::string ASTNode::to_json() const {
     json += "\"uuid\":\"" + escape(get_uuid_str()) + "\",";
 
     // add other properties
-    for (auto property : properties){
-        json += "\"" + property.first + "\":\"" + escape(property.second) + "\",";
+    for (auto property : properties) {
+        json +=
+            "\"" + property.first + "\":\"" + escape(property.second) + "\",";
     }
 
     // has childs
-    if (!childs.empty()){
+    if (!childs.empty()) {
         json += "\"childs\":[";
-        for (auto child : childs){
+        for (auto child : childs) {
             json += child->to_json();
             json += ',';
         }
@@ -48,68 +49,76 @@ std::string ASTNode::to_json() const {
     return json;
 }
 
-std::string ASTNode::to_dot() const {
+std::string ASTNode::concatenated_childs_dot() const {
     std::map<std::string, std::string> properties = get_properties();
 
     std::string node = get_uuid_str();
     std::string label = "";
 
-    for (int i = 1; auto property : properties){
-        label += "<f" + std::to_string(i) + "> " + property.first + ": " + escape(property.second) + " | ";
+    for (int i = 1; auto property : properties) {
+        label += "<f" + std::to_string(i) + "> " + property.first + ": " +
+                 escape(property.second) + " | ";
         i++;
     }
 
     // is Leaf
-    if (childs.empty()){
-        return node + "[label=\"" + get_classname() + " | " + label + "\", shape=\"record\"]\n";
+    if (childs.empty()) {
+        return node + "[label=\"" + get_classname() + " | " + label +
+               "\", shape=\"record\"]\n";
     }
 
     // add child node
     std::string childs_dot = "";
-    for (auto child : childs){
-        childs_dot += child->to_dot();
+    for (auto child : childs) {
+        childs_dot += child->concatenated_childs_dot();
     }
 
     // connect child node
     std::string edges = "";
-    for (auto child : childs){
-        edges += node + ":f" + std::to_string(edges.length()) + " -> " + child->get_uuid_str() + "\n";
+    for (auto child : childs) {
+        edges += node + ":f" + std::to_string(edges.length()) + " -> " +
+                 child->get_uuid_str() + "\n";
     }
 
     // if this node is root, you must format returned string r as follows :
     //     r = "digraph G {\n graph [labelloc=\"t\"; \n ]\n" + r + "}";
-    return node + "[label=\"<f0> " + get_classname() + " | " + label + "\", shape=\"record\"]\n" + childs_dot + edges;
+    return node + "[label=\"<f0> " + get_classname() + " | " + label +
+           "\", shape=\"record\"]\n" + childs_dot + edges;
 }
 
-std::string ASTNode::get_uuid_str() const {
-    return std::to_string(uuid);
-}
+std::string ASTNode::get_uuid_str() const { return std::to_string(uuid); }
 
-void ASTNode::set_uuid(){
-    uuid = uuid_gen();
-}
+void ASTNode::set_uuid() { uuid = uuid_gen(); }
 
-void ASTNode::add_child(std::shared_ptr<ASTNode> child){
+void ASTNode::add_child(std::shared_ptr<ASTNode> child) {
     childs.push_back(child);
+}
+
+void ASTNode::remove_child(std::shared_ptr<ASTNode> child) {
+    childs.erase(std::remove(childs.begin(), childs.end(), child), childs.end());
 }
 
 std::string ASTNode::concatenated_childs_html() const {
     std::string ret = "";
-    for (auto child : childs){
+    for (auto child : childs) {
         ret += child->to_html();
     }
     return ret;
 }
 
+std::vector<std::shared_ptr<ASTNode>> ASTNode::get_childs() const {
+    return childs;
+}
 
-std::vector<std::string> ASTNode::nodes_byclass(const std::string &classname) const {
+std::vector<std::string> ASTNode::nodes_byclass(
+    const std::string &classname) const {
     std::vector<std::string> ret;
-    if (get_classname() == classname){
+    if (get_classname() == classname) {
         ret.push_back(get_uuid_str());
     }
-    for (auto child : childs){
+    for (auto child : childs) {
         std::vector<std::string> childs_ret = child->nodes_byclass(classname);
-        for (auto child_ret : childs_ret){
+        for (auto child_ret : childs_ret) {
             ret.push_back(child_ret);
         }
     }
@@ -117,4 +126,4 @@ std::vector<std::string> ASTNode::nodes_byclass(const std::string &classname) co
 }
 
 
-} // namespace almo
+}  // namespace almo

--- a/src/interfaces/ast.hpp
+++ b/src/interfaces/ast.hpp
@@ -1,22 +1,21 @@
 #pragma once
 
-#include <string>
-#include <vector>
 #include <map>
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace almo {
 
 struct ASTNode {
-
     // html
     virtual std::string to_html() const = 0;
 
     // json
-    std::string to_json() const ;
+    std::string to_json() const;
 
     // dot
-    std::string to_dot() const ;
+    std::string concatenated_childs_dot() const;
 
     // properties
     virtual std::map<std::string, std::string> get_properties() const = 0;
@@ -25,7 +24,7 @@ struct ASTNode {
     virtual std::string get_classname() const = 0;
 
     // get uuid as string
-    std::string get_uuid_str() const ;
+    std::string get_uuid_str() const;
 
     // set uuid
     void set_uuid();
@@ -34,15 +33,16 @@ struct ASTNode {
     void add_child(std::shared_ptr<ASTNode> child);
 
     // child's html
-    std::string concatenated_childs_html() const ;
+    std::string concatenated_childs_html() const;
 
     // get node's uuid from class name
-    std::vector<std::string> nodes_byclass(const std::string &classname) const ;
+    std::vector<std::string> nodes_byclass(const std::string &classname) const;
 
-  protected:
+   protected:
     std::vector<std::shared_ptr<ASTNode>> childs;
-  private:
+
+   private:
     int uuid;
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/interfaces/ast.hpp
+++ b/src/interfaces/ast.hpp
@@ -32,13 +32,18 @@ struct ASTNode {
     // add child
     void add_child(std::shared_ptr<ASTNode> child);
 
+    // remove child
+    void remove_child(std::shared_ptr<ASTNode> child);
+
+    std::vector<std::shared_ptr<ASTNode>> get_childs() const;
+
     // child's html
     std::string concatenated_childs_html() const;
 
     // get node's uuid from class name
     std::vector<std::string> nodes_byclass(const std::string &classname) const;
 
-   protected:
+   public:
     std::vector<std::shared_ptr<ASTNode>> childs;
 
    private:

--- a/src/interfaces/ast.hpp
+++ b/src/interfaces/ast.hpp
@@ -7,7 +7,7 @@
 
 namespace almo {
 
-struct ASTNode {
+struct ASTNode : public std::enable_shared_from_this<ASTNode> {
     // html
     virtual std::string to_html() const = 0;
 
@@ -30,7 +30,7 @@ struct ASTNode {
     void set_uuid();
 
     // add child
-    void add_child(std::shared_ptr<ASTNode> child);
+    void pushback_child(std::shared_ptr<ASTNode> child);
 
     // remove child
     void remove_child(std::shared_ptr<ASTNode> child);
@@ -41,7 +41,11 @@ struct ASTNode {
     std::string concatenated_childs_html() const;
 
     // get node's uuid from class name
-    std::vector<std::string> nodes_byclass(const std::string &classname) const;
+    std::vector<std::shared_ptr<ASTNode>> nodes_byclass(
+        const std::string &classname) const;
+
+    void move_node(std::shared_ptr<ASTNode> node,
+                   std::shared_ptr<ASTNode> new_parent);
 
    public:
     std::vector<std::shared_ptr<ASTNode>> childs;

--- a/src/pyalmo.cpp
+++ b/src/pyalmo.cpp
@@ -32,15 +32,16 @@ PYBIND11_MODULE(almo, m) {
         .def("get_classname", &almo::ASTNode::get_classname)
         .def("get_uuid_str", &almo::ASTNode::get_uuid_str)
         .def("set_uuid", &almo::ASTNode::set_uuid)
-        .def("add_child", &almo::ASTNode::add_child)
+        .def("pushback_child", &almo::ASTNode::pushback_child)
         .def("remove_child", &almo::ASTNode::remove_child)
+        .def("move_node", &almo::ASTNode::move_node)
         .def("concatenated_childs_html",
              &almo::ASTNode::concatenated_childs_html)
         .def("nodes_byclass", &almo::ASTNode::nodes_byclass)
         .def_readwrite("childs", &almo::ASTNode::childs)
         .def("get_childs", &almo::ASTNode::get_childs)
         .def("__repr__", [](const almo::ASTNode &ast_node) {
-            return "<almo" + ast_node.get_classname() +
+            return "<almo." + ast_node.get_classname() +
                    " (uuid: " + ast_node.get_uuid_str() + ")>";
         });
 

--- a/src/pyalmo.cpp
+++ b/src/pyalmo.cpp
@@ -1,7 +1,13 @@
 #include <pybind11/pybind11.h>
-#include <pybind11/stl.h> 
+#include <pybind11/stl.h>
 
 #include "almo.cpp"
+
+// Macro to bind node
+#define BIND_NODE(CLASS, BIND_CLASSNAME, CONSTRUCTOR_ARGS...)                \
+    py::class_<CLASS, almo::ASTNode, std::shared_ptr<CLASS>>(m,              \
+                                                             BIND_CLASSNAME) \
+        .def(py::init<CONSTRUCTOR_ARGS>())
 
 almo::Markdown parse_md(std::string md_content) {
     almo::Markdown ast;
@@ -16,17 +22,72 @@ namespace py = pybind11;
 PYBIND11_MODULE(almo, m) {
     m.doc() = "almo interface for python.";
 
-    m.def("parse_md", &parse_md, "Parse markdown to AST.");
+    m.def("parse", &parse_md, "Parse markdown to AST.");
 
-    py::class_<almo::Markdown>(m, "Markdown")
+    py::class_<almo::ASTNode, std::shared_ptr<almo::ASTNode>>(
+        m, "ASTNode", py::dynamic_attr())
+        .def("to_html", &almo::ASTNode::to_html)
+        .def("to_json", &almo::ASTNode::to_json)
+        .def("get_properties", &almo::ASTNode::get_properties)
+        .def("get_classname", &almo::ASTNode::get_classname)
+        .def("get_uuid_str", &almo::ASTNode::get_uuid_str)
+        .def("set_uuid", &almo::ASTNode::set_uuid)
+        .def("add_child", &almo::ASTNode::add_child)
+        .def("remove_child", &almo::ASTNode::remove_child)
+        .def("concatenated_childs_html",
+             &almo::ASTNode::concatenated_childs_html)
+        .def("nodes_byclass", &almo::ASTNode::nodes_byclass)
+        .def_readwrite("childs", &almo::ASTNode::childs)
+        .def("get_childs", &almo::ASTNode::get_childs)
+        .def("__repr__", [](const almo::ASTNode &ast_node) {
+            return "<almo" + ast_node.get_classname() +
+                   " (uuid: " + ast_node.get_uuid_str() + ")>";
+        });
+
+    py::class_<almo::Markdown, almo::ASTNode, std::shared_ptr<almo::Markdown>>(
+        m, "Markdown")
+        .def(py::init<>())
         .def("to_html", &almo::Markdown::to_html)
         .def("to_dot", &almo::Markdown::to_dot)
         .def("to_json", &almo::Markdown::to_json)
-        .def("nodes_byclass", &almo::Markdown::nodes_byclass);
+        .def("__repr__", [](const almo::Markdown &md_ast) {
+            return "<almo.Markdown (uuid: " + md_ast.get_uuid_str() + ")>";
+        });
 
-    #ifdef VERSION_INFO
-        m.attr("__version__") = VERSION_INFO;
-    #else
-        m.attr("__version__") = "dev";
-    #endif
+    // CLASS, CONSTRUCTOR_ARGS
+    BIND_NODE(almo::CodeBlock, "CodeBlock", std::string, std::string);
+    BIND_NODE(almo::DivBlock, "DivBlock", std::string);
+    BIND_NODE(almo::EnumerateBlock, "EnumerateBlock");
+    BIND_NODE(almo::ExecutableCodeBlock, "ExecutableCodeBlock", std::string,
+              std::string);
+    BIND_NODE(almo::FootnoteDefinition, "FootnoteDefinition", std::string);
+    BIND_NODE(almo::Header, "Header", int);
+    BIND_NODE(almo::HorizontalLine, "HorizontalLine");
+    BIND_NODE(almo::InlineCodeBlock, "InlineCodeBlock", std::string);
+    BIND_NODE(almo::InlineFootnoteReference, "InlineFootnoteReference",
+              std::string);
+    BIND_NODE(almo::InlineImage, "InlineImage", std::string, std::string);
+    BIND_NODE(almo::InlineItalic, "InlineItalic");
+    BIND_NODE(almo::InlineMath, "InlineMath", std::string);
+    BIND_NODE(almo::InlineOverline, "InlineOverline");
+    BIND_NODE(almo::InlineStrong, "InlineStrong");
+    BIND_NODE(almo::InlineUrl, "InlineUrl", std::string, std::string);
+    BIND_NODE(almo::Item, "Item");
+    BIND_NODE(almo::Judge, "Judge", std::string, std::string, std::string,
+              std::string, std::string, std::string, std::string, std::string);
+    BIND_NODE(almo::ListBlock, "ListBlock");
+    BIND_NODE(almo::LoadLib, "LoadLib", std::vector<std::string>);
+    BIND_NODE(almo::MathBlock, "MathBlock", std::string);
+    BIND_NODE(almo::NewLine, "NewLine");
+    BIND_NODE(almo::Quote, "Quote");
+    BIND_NODE(almo::RawText, "RawText", std::string);
+    BIND_NODE(almo::Table, "Table",
+              std::vector<std::shared_ptr<almo::Markdown>>, int, int,
+              std::vector<std::string>, std::vector<int>);
+
+#ifdef VERSION_INFO
+    m.attr("__version__") = VERSION_INFO;
+#else
+    m.attr("__version__") = "dev";
+#endif
 }

--- a/src/syntax/CodeBlock.hpp
+++ b/src/syntax/CodeBlock.hpp
@@ -1,25 +1,28 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
-
-#include"../utils.hpp"
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
+#include "../utils.hpp"
 
 namespace almo {
 
-// コードブロックを表すクラス.  <div class="code-block"> タグで囲まれ、その中に <pre><code> タグが入る.
+// コードブロックを表すクラス.  <div class="code-block"> タグで囲まれ、その中に
+// <pre><code> タグが入る.
 struct CodeBlock : public ASTNode {
-  private:
+   private:
     // コードの中身。
     std::string code;
 
-    // Highlight.js によって正確にハイライトするために、言語を指定する必要がある。
-    // ```python -> python を持っておき、 `to_html` する際に <code class="language-python"> として出力する。
+    // Highlight.js
+    // によって正確にハイライトするために、言語を指定する必要がある。
+    // ```python -> python を持っておき、 `to_html` する際に <code
+    // class="language-python"> として出力する。
     std::string language;
 
-  public:
-    CodeBlock(std::string code, std::string language) : code(code), language(language) {
+   public:
+    CodeBlock(std::string code, std::string language)
+        : code(code), language(language) {
         set_uuid();
     }
 
@@ -32,19 +35,15 @@ struct CodeBlock : public ASTNode {
             code_class = "language-" + language;
         }
 
-        return "<div class=\"code-block\"> <pre><code class=\"" + code_class + "\">" + escape_for_html(code) + "</code></pre> </div>";
+        return "<div class=\"code-block\"> <pre><code class=\"" + code_class +
+               "\">" + escape_for_html(code) + "</code></pre> </div>";
     }
 
     std::map<std::string, std::string> get_properties() const override {
-        return {
-            {"code", code},
-            {"language", language}
-        };
+        return {{"code", code}, {"language", language}};
     }
 
-    std::string get_classname() const override {
-        return "CodeBlock";
-    }
+    std::string get_classname() const override { return "CodeBlock"; }
 };
 
 struct CodeBlockSyntax : public BlockSyntax {
@@ -55,12 +54,12 @@ struct CodeBlockSyntax : public BlockSyntax {
     void operator()(Reader &read, ASTNode &ast) const override {
         // BEGIN : '```(.*)'
         // END   : '```\s*'
-        
+
         std::string language = rtrim(read.get_row().substr(3));
         read.move_next_line();
         std::string code;
-        while (!read.is_eof()){
-            if (rtrim(read.get_row()) == "```"){
+        while (!read.is_eof()) {
+            if (rtrim(read.get_row()) == "```") {
                 read.move_next_line();
                 break;
             }
@@ -69,8 +68,8 @@ struct CodeBlockSyntax : public BlockSyntax {
         }
 
         CodeBlock node(code, language);
-        ast.add_child(std::make_shared<CodeBlock>(node));
+        ast.pushback_child(std::make_shared<CodeBlock>(node));
     }
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/DivBlock.hpp
+++ b/src/syntax/DivBlock.hpp
@@ -1,24 +1,23 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
-#include"../utils.hpp"
-
-#include"Markdown.hpp"
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
+#include "../utils.hpp"
+#include "Markdown.hpp"
 
 namespace almo {
 
 struct DivBlock : public ASTNode {
-  private:
+   private:
     std::string div_class;
-  public:
-    DivBlock(std::string div_class) : div_class(div_class) {
-        set_uuid();
-    }
+
+   public:
+    DivBlock(std::string div_class) : div_class(div_class) { set_uuid(); }
 
     std::string to_html() const override {
-        return "<div class=\"" + div_class + "\">" + concatenated_childs_html() + "</div>";
+        return "<div class=\"" + div_class + "\">" +
+               concatenated_childs_html() + "</div>";
     }
 
     std::map<std::string, std::string> get_properties() const override {
@@ -26,9 +25,7 @@ struct DivBlock : public ASTNode {
             {"div_class", div_class},
         };
     }
-    std::string get_classname() const override {
-        return "DivBlock";
-    }
+    std::string get_classname() const override { return "DivBlock"; }
 };
 
 struct DivBlockSyntax : public BlockSyntax {
@@ -48,36 +45,36 @@ struct DivBlockSyntax : public BlockSyntax {
         read.move_next_line();
         std::vector<std::string> text;
 
-        while (!read.is_eof()){
+        while (!read.is_eof()) {
             // Invariant : scopes.size() >= 1
-            if (rtrim(read.get_row()) == ":::"){
+            if (rtrim(read.get_row()) == ":::") {
                 Markdown inner_md;
                 MarkdownParser parser(text);
                 parser.process(inner_md);
                 auto inner_md_ptr = std::make_shared<Markdown>(inner_md);
-                scopes.top()->add_child(inner_md_ptr);
+                scopes.top()->pushback_child(inner_md_ptr);
 
                 text = {};
                 read.move_next_line();
 
-                if (scopes.size() == 1u){
-                    ast.add_child(scopes.top());
+                if (scopes.size() == 1u) {
+                    ast.pushback_child(scopes.top());
                     scopes.pop();
                     break;
                 }
                 scopes.pop();
                 continue;
             }
-            if (read.get_row().starts_with(":::")){
+            if (read.get_row().starts_with(":::")) {
                 Markdown inner_md;
                 MarkdownParser parser(text);
                 parser.process(inner_md);
                 auto inner_md_ptr = std::make_shared<Markdown>(inner_md);
-                scopes.top()->add_child(inner_md_ptr);
+                scopes.top()->pushback_child(inner_md_ptr);
 
                 DivBlock new_node(read.get_row().substr(3));
                 auto new_node_ptr = std::make_shared<DivBlock>(new_node);
-                scopes.top()->add_child(new_node_ptr);
+                scopes.top()->pushback_child(new_node_ptr);
 
                 scopes.push(new_node_ptr);
 
@@ -89,17 +86,17 @@ struct DivBlockSyntax : public BlockSyntax {
             read.move_next_line();
         }
         // scopes.empty() iff completed DivBlock
-        while (!scopes.empty()){
+        while (!scopes.empty()) {
             Markdown inner_md;
             MarkdownParser parser(text);
             parser.process(inner_md);
             auto inner_md_ptr = std::make_shared<Markdown>(inner_md);
-            scopes.top()->add_child(inner_md_ptr);
+            scopes.top()->pushback_child(inner_md_ptr);
 
             text = {};
 
-            if (scopes.size() == 1u){
-                ast.add_child(scopes.top());
+            if (scopes.size() == 1u) {
+                ast.pushback_child(scopes.top());
                 scopes.pop();
                 break;
             }
@@ -110,4 +107,4 @@ struct DivBlockSyntax : public BlockSyntax {
     }
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/EOF.hpp
+++ b/src/syntax/EOF.hpp
@@ -1,18 +1,16 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
 
 namespace almo {
 
 struct EOFSyntax : public BlockSyntax {
-    bool operator()(Reader &read) const override {
-        return read.is_eof();
-    }
+    bool operator()(Reader &read) const override { return read.is_eof(); }
     void operator()(Reader &read, ASTNode &ast) const override {
         read.read_eof();
     }
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/EnumerateBlock.hpp
+++ b/src/syntax/EnumerateBlock.hpp
@@ -1,34 +1,28 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
-#include"../utils.hpp"
-
-#include"Item.hpp"
-#include"NewLine.hpp"
-#include"EOF.hpp"
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
+#include "../utils.hpp"
+#include "EOF.hpp"
+#include "Item.hpp"
+#include "NewLine.hpp"
 
 namespace almo {
 
-// 番号付き箇条書きを表すクラス 
+// 番号付き箇条書きを表すクラス
 struct EnumerateBlock : public ASTNode {
-  public:
-    EnumerateBlock() {
-        set_uuid();
-    }
+   public:
+    EnumerateBlock() { set_uuid(); }
 
     std::string to_html() const override {
         return "<ol>" + concatenated_childs_html() + "</ol>";
     }
 
     std::map<std::string, std::string> get_properties() const override {
-        return {
-        };
+        return {};
     }
-    std::string get_classname() const override {
-        return "EnumerateBlock";
-    }
+    std::string get_classname() const override { return "EnumerateBlock"; }
 };
 
 struct EnumerateBlockSyntax : public BlockSyntax {
@@ -63,10 +57,10 @@ struct EnumerateBlockSyntax : public BlockSyntax {
 
         std::string text = "";
 
-        while (true){
+        while (true) {
             // Invariant : read.is_eof() == false
             //             scopes.size() >= 1
-            text += [&]{
+            text += [&] {
                 std::smatch sm;
                 // smatch manage an iterator of the matched string `line`
                 // --> the string should not be a temporary object
@@ -79,32 +73,33 @@ struct EnumerateBlockSyntax : public BlockSyntax {
             read.move_next_line();
 
             // END
-            if (EOFSyntax{}(read) || NewLineSyntax{}(read)){
+            if (EOFSyntax{}(read) || NewLineSyntax{}(read)) {
                 Item item;
                 InlineParser::process(text, item);
-                scopes.top()->add_child(std::make_shared<Item>(item));
+                scopes.top()->pushback_child(std::make_shared<Item>(item));
                 text = "";
                 break;
             }
             // same depth
-            if (std::regex_match(read.get_row(), std::regex(current_match))){
+            if (std::regex_match(read.get_row(), std::regex(current_match))) {
                 Item item;
                 InlineParser::process(text, item);
-                scopes.top()->add_child(std::make_shared<Item>(item));
+                scopes.top()->pushback_child(std::make_shared<Item>(item));
                 text = "";
                 continue;
             }
             // +3 depth
-            if (std::regex_match(read.get_row(), std::regex(INDENT + current_match))){
+            if (std::regex_match(read.get_row(),
+                                 std::regex(INDENT + current_match))) {
                 Item item;
                 InlineParser::process(text, item);
-                scopes.top()->add_child(std::make_shared<Item>(item));
+                scopes.top()->pushback_child(std::make_shared<Item>(item));
                 text = "";
 
                 // nested EnumerateBlock
                 EnumerateBlock new_node;
                 auto new_node_ptr = std::make_shared<EnumerateBlock>(new_node);
-                scopes.top()->add_child(new_node_ptr);
+                scopes.top()->pushback_child(new_node_ptr);
                 scopes.push(new_node_ptr);
 
                 // update match
@@ -112,38 +107,46 @@ struct EnumerateBlockSyntax : public BlockSyntax {
                 continue;
             }
             // -3n depth (n >= 1)
-            if ([&]{
-                std::size_t depth = enum_depth(read.get_row());
-                if (depth == std::string::npos) return false;
-                std::size_t current = (scopes.size() - 1u) * 3u;
-                // depth == current, depth == current + 3 is already ditected
-                // depth has decreased and the difference is multiple of 3
-                if (depth < current && (current - depth) % 3 == 0) return true;
-                // ambiguous enum definition detected
-                std::cerr << "Warning: ambiguous enum\n ... \n" << read.near() << "\n^^^ parsing line" << std::endl;
-                std::cerr << "indent width must be 3. this line is considered as raw text." << std::endl;
-                return false;
-            }()){
-                std::size_t delete_indent = (scopes.size() - 1u) * 3u - enum_depth(read.get_row());
+            if ([&] {
+                    std::size_t depth = enum_depth(read.get_row());
+                    if (depth == std::string::npos) return false;
+                    std::size_t current = (scopes.size() - 1u) * 3u;
+                    // depth == current, depth == current + 3 is already
+                    // ditected depth has decreased and the difference is
+                    // multiple of 3
+                    if (depth < current && (current - depth) % 3 == 0)
+                        return true;
+                    // ambiguous enum definition detected
+                    std::cerr << "Warning: ambiguous enum\n ... \n"
+                              << read.near() << "\n^^^ parsing line"
+                              << std::endl;
+                    std::cerr << "indent width must be 3. this line is "
+                                 "considered as raw text."
+                              << std::endl;
+                    return false;
+                }()) {
+                std::size_t delete_indent =
+                    (scopes.size() - 1u) * 3u - enum_depth(read.get_row());
                 current_match = current_match.substr(delete_indent);
 
                 Item item;
                 InlineParser::process(text, item);
-                scopes.top()->add_child(std::make_shared<Item>(item));
+                scopes.top()->pushback_child(std::make_shared<Item>(item));
                 text = "";
 
-                for (std::size_t del = 0; del < delete_indent; del += 3u){
+                for (std::size_t del = 0; del < delete_indent; del += 3u) {
                     scopes.pop();
                 }
                 continue;
             }
-            // Ensure : read.get_row() is considered a continuation of the previous item
+            // Ensure : read.get_row() is considered a continuation of the
+            // previous item
         }
-        while (scopes.size() > 1u){
+        while (scopes.size() > 1u) {
             scopes.pop();
         }
-        ast.add_child(scopes.top());
+        ast.pushback_child(scopes.top());
     }
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/ExecutableCodeBlock.hpp
+++ b/src/syntax/ExecutableCodeBlock.hpp
@@ -1,20 +1,22 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
-#include"../utils.hpp"
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
+#include "../utils.hpp"
 
 namespace almo {
 
-// 実行可能なコードブロックを表すクラス. 
+// 実行可能なコードブロックを表すクラス.
 // `Judge` と異なり、こちらはジャッジを提供せず、単に実行のみを行う。
 struct ExecutableCodeBlock : public ASTNode {
-  private:
+   private:
     std::string code;
     std::string editor_theme;
-  public:
-    ExecutableCodeBlock(std::string code, std::string editor_theme) : code(code), editor_theme(editor_theme) {
+
+   public:
+    ExecutableCodeBlock(std::string code, std::string editor_theme)
+        : code(code), editor_theme(editor_theme) {
         set_uuid();
     }
 
@@ -24,11 +26,17 @@ struct ExecutableCodeBlock : public ASTNode {
 
         std::string uuid_str = get_uuid_str();
 
-        // `minLines` と `maxLines` を適切に設定してコード全体を表示するようにする。
-        std::string ace_editor = ""
+        // `minLines` と `maxLines`
+        // を適切に設定してコード全体を表示するようにする。
+        std::string ace_editor =
+            ""
             "<script>"
-            "editor = ace.edit(\"" + uuid_str + "\"); "
-            "editor.setTheme(\"" + editor_theme + "\");"
+            "editor = ace.edit(\"" +
+            uuid_str +
+            "\"); "
+            "editor.setTheme(\"" +
+            editor_theme +
+            "\");"
             "editor.session.setMode(\"ace/mode/python\");"
             "editor.setShowPrintMargin(false);"
             "editor.setHighlightActiveLine(false);"
@@ -36,35 +44,44 @@ struct ExecutableCodeBlock : public ASTNode {
             "    enableBasicAutocompletion: true,"
             "    enableSnippets: true,"
             "    enableLiveAutocompletion: true,"
-            "    minLines: " + std::to_string(n_line + 1) + ", "
-            "    maxLines: " + std::to_string(n_line + 1) + ", "
+            "    minLines: " +
+            std::to_string(n_line + 1) +
+            ", "
+            "    maxLines: " +
+            std::to_string(n_line + 1) +
+            ", "
             "    fontSize: \"14px\""
             "});"
             "editor.renderer.setScrollMargin(10, 10);"
-            "editor.setValue(`" + code + "`, -1);"
+            "editor.setValue(`" +
+            code +
+            "`, -1);"
             "</script>\n";
 
-        // 通常の出力に加えて、matplotlib のプロットを表示するための div を作っておく。
-        std::string editor_div = "<br> \n <div class=\"editor\" id=\"" + uuid_str + "\" rows=\"3\" cols=\"80\"></div> \n";
-        std::string out_area = "<pre class=\"exec_out\" id=\"" + uuid_str + "_out\"></pre>\n";
-        std::string plot_area = "<div class=\"exec_plot\" id=\"" + uuid_str + "_plot\"></div>\n";
+        // 通常の出力に加えて、matplotlib のプロットを表示するための div
+        // を作っておく。
+        std::string editor_div = "<br> \n <div class=\"editor\" id=\"" +
+                                 uuid_str +
+                                 "\" rows=\"3\" cols=\"80\"></div> \n";
+        std::string out_area =
+            "<pre class=\"exec_out\" id=\"" + uuid_str + "_out\"></pre>\n";
+        std::string plot_area =
+            "<div class=\"exec_plot\" id=\"" + uuid_str + "_plot\"></div>\n";
 
         std::string run_button =
-            "<button class=\"runbutton\" onclick=\"runBlock('" + uuid_str + "')\"> Run </button>\n";
+            "<button class=\"runbutton\" onclick=\"runBlock('" + uuid_str +
+            "')\"> Run </button>\n";
 
-        std::string output = editor_div + ace_editor + out_area + plot_area + run_button;
+        std::string output =
+            editor_div + ace_editor + out_area + plot_area + run_button;
 
         return output;
     }
 
     std::map<std::string, std::string> get_properties() const override {
-        return {
-            {"code", code}
-        };
+        return {{"code", code}};
     }
-    std::string get_classname() const override {
-        return "ExecutableCodeBlock";
-    }
+    std::string get_classname() const override { return "ExecutableCodeBlock"; }
 };
 
 struct ExecutableCodeBlockSyntax : public BlockSyntax {
@@ -79,8 +96,8 @@ struct ExecutableCodeBlockSyntax : public BlockSyntax {
         // skip :::code
         read.move_next_line();
 
-        while (!read.is_eof()){
-            if (rtrim(read.get_row()) == ":::"){
+        while (!read.is_eof()) {
+            if (rtrim(read.get_row()) == ":::") {
                 read.move_next_line();
                 break;
             }
@@ -89,8 +106,8 @@ struct ExecutableCodeBlockSyntax : public BlockSyntax {
         }
 
         ExecutableCodeBlock node(code, "{{ editor_theme }}");
-        ast.add_child(std::make_shared<ExecutableCodeBlock>(node));
+        ast.pushback_child(std::make_shared<ExecutableCodeBlock>(node));
     }
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/FootnoteDefinition.hpp
+++ b/src/syntax/FootnoteDefinition.hpp
@@ -1,30 +1,27 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
-#include"../utils.hpp"
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
+#include "../utils.hpp"
 
-namespace almo{
+namespace almo {
 struct FootnoteDefinition : public ASTNode {
-  private:
+   private:
     std::string tag;
-  public:
-    FootnoteDefinition (std::string tag_) : tag(tag_){
-        set_uuid();
-    }
+
+   public:
+    FootnoteDefinition(std::string tag_) : tag(tag_) { set_uuid(); }
     std::string to_html() const override {
         std::string childs_html = concatenated_childs_html();
-        return "<span class=\"footnote_def\"> <li id=\"note_" + tag +"\"><a href=\"#ref_" + tag + "\">^" + tag + "</a>" + childs_html +"</li> </span>";
+        return "<span class=\"footnote_def\"> <li id=\"note_" + tag +
+               "\"><a href=\"#ref_" + tag + "\">^" + tag + "</a>" +
+               childs_html + "</li> </span>";
     }
     std::map<std::string, std::string> get_properties() const override {
-        return {
-            {"tag", tag}
-        };
+        return {{"tag", tag}};
     }
-    std::string get_classname() const override {
-        return "FootnoteDefinition";
-    }
+    std::string get_classname() const override { return "FootnoteDefinition"; }
 };
 
 struct FootnoteDefinitionSyntax : public BlockSyntax {
@@ -44,8 +41,8 @@ struct FootnoteDefinitionSyntax : public BlockSyntax {
         assert(std::regex_match(row, sm, rex));
         FootnoteDefinition node(sm.format("$1"));
         InlineParser::process(sm.format("$2"), node);
-        ast.add_child(std::make_shared<FootnoteDefinition>(node));
+        ast.pushback_child(std::make_shared<FootnoteDefinition>(node));
         read.move_next_line();
     }
 };
-}
+}  // namespace almo

--- a/src/syntax/Header.hpp
+++ b/src/syntax/Header.hpp
@@ -1,40 +1,44 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
 
 namespace almo {
 
 struct Header : public ASTNode {
-  private:
+   private:
     int level;
-  public:
-    Header (int _level) : level(_level) {
-        set_uuid();
-    }
+
+   public:
+    Header(int _level) : level(_level) { set_uuid(); }
     std::string to_html() const override {
         std::string childs_html = concatenated_childs_html();
-        std::string contents_push = ""
+        std::string contents_push =
+            ""
             "<script>"
             "page_contents.push({\n"
-            "    \"type\":\"H" + std::to_string(level) + "\",\n"
-            "    \"id\":\"" + get_uuid_str() + "\",\n"
-            "    \"title\":\"" + childs_html + "\"\n"
+            "    \"type\":\"H" +
+            std::to_string(level) +
+            "\",\n"
+            "    \"id\":\"" +
+            get_uuid_str() +
+            "\",\n"
+            "    \"title\":\"" +
+            childs_html +
+            "\"\n"
             "});\n"
             "</script>\n";
 
-        return contents_push + "<h" + std::to_string(level) + " id=\"" + get_uuid_str() + "\">" + childs_html + "</h" + std::to_string(level) + ">";
+        return contents_push + "<h" + std::to_string(level) + " id=\"" +
+               get_uuid_str() + "\">" + childs_html + "</h" +
+               std::to_string(level) + ">";
     }
 
     std::map<std::string, std::string> get_properties() const override {
-        return {
-            {"level", std::to_string(level)}
-        };
+        return {{"level", std::to_string(level)}};
     }
-    std::string get_classname() const override {
-        return "Header";
-    }
+    std::string get_classname() const override { return "Header"; }
 };
 
 struct HeaderSyntax : BlockSyntax {
@@ -58,10 +62,10 @@ struct HeaderSyntax : BlockSyntax {
         if (read.get_row().starts_with("###### ")) level = 6;
         assert(1 <= level && level <= 6);
         Header node(level);
-        InlineParser::process(read.get_row().substr(level+1), node);
-        ast.add_child(std::make_shared<Header>(node));
+        InlineParser::process(read.get_row().substr(level + 1), node);
+        ast.pushback_child(std::make_shared<Header>(node));
         read.move_next_line();
     }
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/HorizontalLine.hpp
+++ b/src/syntax/HorizontalLine.hpp
@@ -1,29 +1,22 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
-#include"../utils.hpp"
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
+#include "../utils.hpp"
 
 namespace almo {
 
 struct HorizontalLine : public ASTNode {
-  public:
-    HorizontalLine() {
-        set_uuid();
-    }
+   public:
+    HorizontalLine() { set_uuid(); }
 
-    std::string to_html() const override {
-        return "<hr>";
-    }
+    std::string to_html() const override { return "<hr>"; }
 
     std::map<std::string, std::string> get_properties() const override {
-        return {
-        };
+        return {};
     }
-    std::string get_classname() const override {
-        return "HorizontalLine";
-    }
+    std::string get_classname() const override { return "HorizontalLine"; }
 };
 
 struct HorizontalLineSyntax : BlockSyntax {
@@ -36,9 +29,9 @@ struct HorizontalLineSyntax : BlockSyntax {
     }
     void operator()(Reader &read, ASTNode &ast) const override {
         HorizontalLine node;
-        ast.add_child(std::make_shared<HorizontalLine>(node));
+        ast.pushback_child(std::make_shared<HorizontalLine>(node));
         read.move_next_line();
     }
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/InlineCodeBlock.hpp
+++ b/src/syntax/InlineCodeBlock.hpp
@@ -1,40 +1,35 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
-#include"../utils.hpp"
-
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
+#include "../utils.hpp"
 
 namespace almo {
 
 struct InlineCodeBlock : public ASTNode {
-  private:
+   private:
     std::string code;
-  public:
-    InlineCodeBlock(std::string code) : code(code) {
-        set_uuid();
-    }
+
+   public:
+    InlineCodeBlock(std::string code) : code(code) { set_uuid(); }
 
     std::string to_html() const override {
-        return "<span class=\"inline-code\"> <code>" + escape_for_html(code) + "</code> </span>";
+        return "<span class=\"inline-code\"> <code>" + escape_for_html(code) +
+               "</code> </span>";
     }
 
     std::map<std::string, std::string> get_properties() const override {
-        return {
-            {"code", code}
-        };
+        return {{"code", code}};
     }
-    std::string get_classname() const override {
-        return "InlineCodeBlock";
-    }
+    std::string get_classname() const override { return "InlineCodeBlock"; }
 };
 
 struct InlineCodeBlockSyntax : public InlineSyntax {
     static inline const std::regex rex = std::regex(R"((.*?)\`(.*?)\`(.*))");
     int operator()(const std::string &str) const override {
         std::smatch sm;
-        if (std::regex_search(str, sm, rex)){
+        if (std::regex_search(str, sm, rex)) {
             return sm.position(2) - 1;
         }
         return std::numeric_limits<int>::max();
@@ -47,9 +42,9 @@ struct InlineCodeBlockSyntax : public InlineSyntax {
         std::string suffix = sm.format("$3");
         InlineParser::process(prefix, ast);
         InlineCodeBlock node(code);
-        ast.add_child(std::make_shared<InlineCodeBlock>(node));
+        ast.pushback_child(std::make_shared<InlineCodeBlock>(node));
         InlineParser::process(suffix, ast);
     }
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/InlineFootnoteReference.hpp
+++ b/src/syntax/InlineFootnoteReference.hpp
@@ -1,28 +1,28 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
-#include"../utils.hpp"
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
+#include "../utils.hpp"
 
-namespace almo{
-struct InlineFootnoteReference : public ASTNode{
-  private:
+namespace almo {
+struct InlineFootnoteReference : public ASTNode {
+   private:
     std::string symbol;
-    
-  public:
-    InlineFootnoteReference (std::string _symbol) : symbol(_symbol){
+
+   public:
+    InlineFootnoteReference(std::string _symbol) : symbol(_symbol) {
         set_uuid();
     }
 
     std::string to_html() const override {
-        return "<span class=\"footnote-ref\"> <sup id=\"ref_" + symbol + "\"><a href=\"#note_" + symbol +"\">[" + symbol + "]</a></sup> </span>";
+        return "<span class=\"footnote-ref\"> <sup id=\"ref_" + symbol +
+               "\"><a href=\"#note_" + symbol + "\">[" + symbol +
+               "]</a></sup> </span>";
     }
 
     std::map<std::string, std::string> get_properties() const override {
-        return {
-            {"symbol", symbol}
-        };
+        return {{"symbol", symbol}};
     }
     std::string get_classname() const override {
         return "InlineFootnoteReference";
@@ -32,7 +32,7 @@ struct InlineFootnoteReferenceSyntax : public InlineSyntax {
     static inline const std::regex rex = std::regex(R"((.*?)\[\^(.*?)\](.*))");
     int operator()(const std::string &str) const override {
         std::smatch sm;
-        if (std::regex_search(str, sm, rex)){
+        if (std::regex_search(str, sm, rex)) {
             return sm.position(2) - 1;
         }
         return std::numeric_limits<int>::max();
@@ -45,8 +45,8 @@ struct InlineFootnoteReferenceSyntax : public InlineSyntax {
         std::string suffix = sm.format("$3");
         InlineParser::process(prefix, ast);
         InlineFootnoteReference node(symbol);
-        ast.add_child(std::make_shared<InlineFootnoteReference>(node));
+        ast.pushback_child(std::make_shared<InlineFootnoteReference>(node));
         InlineParser::process(suffix, ast);
     }
 };
-}
+}  // namespace almo

--- a/src/syntax/InlineImage.hpp
+++ b/src/syntax/InlineImage.hpp
@@ -1,24 +1,24 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
-#include"../utils.hpp"
-
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
+#include "../utils.hpp"
 
 namespace almo {
 
 struct InlineImage : public ASTNode {
-  private:
+   private:
     std::string url;
     std::string caption;
 
-  public:
-    InlineImage(std::string url, std::string caption) : url(url), caption(caption) {
+   public:
+    InlineImage(std::string url, std::string caption)
+        : url(url), caption(caption) {
         set_uuid();
     }
 
-    //　<figure> タグを使うことで キャプションなどをつける。
+    // 　<figure> タグを使うことで キャプションなどをつける。
     std::string to_html() const override {
         std::string output = "<img src=\"" + url + "\" >";
         std::string figcaption = "<figcaption>" + caption + "</figcaption>";
@@ -26,21 +26,17 @@ struct InlineImage : public ASTNode {
     }
 
     std::map<std::string, std::string> get_properties() const override {
-        return {
-            {"url", url},
-            {"caption", caption}
-        };
+        return {{"url", url}, {"caption", caption}};
     }
-    std::string get_classname() const override {
-        return "InlineImage";
-    }
+    std::string get_classname() const override { return "InlineImage"; }
 };
 
 struct InlineImageSyntax : public InlineSyntax {
-    static inline const std::regex rex = std::regex(R"((.*?)\!\[(.*?)\]\((.*?)\)(.*))");
+    static inline const std::regex rex =
+        std::regex(R"((.*?)\!\[(.*?)\]\((.*?)\)(.*))");
     int operator()(const std::string &str) const override {
         std::smatch sm;
-        if (std::regex_search(str, sm, rex)){
+        if (std::regex_search(str, sm, rex)) {
             return sm.position(2) - 2;
         }
         return std::numeric_limits<int>::max();
@@ -54,9 +50,9 @@ struct InlineImageSyntax : public InlineSyntax {
         std::string suffix = sm.format("$4");
         InlineParser::process(prefix, ast);
         InlineImage node(url, caption);
-        ast.add_child(std::make_shared<InlineImage>(node));
+        ast.pushback_child(std::make_shared<InlineImage>(node));
         InlineParser::process(suffix, ast);
     }
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/InlineItalic.hpp
+++ b/src/syntax/InlineItalic.hpp
@@ -1,35 +1,31 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
 
 namespace almo {
 
 struct InlineItalic : public ASTNode {
-  public:
-    InlineItalic() {
-        set_uuid();
-    }
+   public:
+    InlineItalic() { set_uuid(); }
 
     std::string to_html() const override {
-        return "<span class=\"italic\"> <i>" + concatenated_childs_html() + "</i> </span>";
+        return "<span class=\"italic\"> <i>" + concatenated_childs_html() +
+               "</i> </span>";
     }
 
     std::map<std::string, std::string> get_properties() const override {
-        return {
-        };
+        return {};
     }
-    std::string get_classname() const override {
-        return "InlineItalic";
-    }
+    std::string get_classname() const override { return "InlineItalic"; }
 };
 
 struct InlineItalicSyntax : public InlineSyntax {
     static inline const std::regex rex = std::regex(R"((.*?)\*(.*?)\*(.*))");
     int operator()(const std::string &str) const override {
         std::smatch sm;
-        if (std::regex_search(str, sm, rex)){
+        if (std::regex_search(str, sm, rex)) {
             return sm.position(2) - 1;
         }
         return std::numeric_limits<int>::max();
@@ -43,9 +39,9 @@ struct InlineItalicSyntax : public InlineSyntax {
         InlineParser::process(prefix, ast);
         InlineItalic node;
         InlineParser::process(content, node);
-        ast.add_child(std::make_shared<InlineItalic>(node));
+        ast.pushback_child(std::make_shared<InlineItalic>(node));
         InlineParser::process(suffix, ast);
     }
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/InlineMath.hpp
+++ b/src/syntax/InlineMath.hpp
@@ -1,19 +1,18 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
-#include"../utils.hpp"
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
+#include "../utils.hpp"
 
 namespace almo {
 
 struct InlineMath : public ASTNode {
-  private:
+   private:
     std::string expr;
-  public:
-    InlineMath (std::string _expr) : expr(_expr) {
-        set_uuid();
-    }
+
+   public:
+    InlineMath(std::string _expr) : expr(_expr) { set_uuid(); }
 
     // mathjax の　インライン数式用に \( \) で囲む
     std::string to_html() const override {
@@ -21,20 +20,16 @@ struct InlineMath : public ASTNode {
     }
 
     std::map<std::string, std::string> get_properties() const override {
-        return {
-            {"expr", expr}
-        };
+        return {{"expr", expr}};
     }
-    std::string get_classname() const override {
-        return "InlineMath";
-    }
+    std::string get_classname() const override { return "InlineMath"; }
 };
 
 struct InlineMathSyntax : public InlineSyntax {
     static inline const std::regex rex = std::regex(R"((.*?)\$(.*?)\$(.*))");
     int operator()(const std::string &str) const override {
         std::smatch sm;
-        if (std::regex_search(str, sm, rex)){
+        if (std::regex_search(str, sm, rex)) {
             return sm.position(2) - 1;
         }
         return std::numeric_limits<int>::max();
@@ -47,9 +42,9 @@ struct InlineMathSyntax : public InlineSyntax {
         std::string suffix = sm.format("$3");
         InlineParser::process(prefix, ast);
         InlineMath node(expr);
-        ast.add_child(std::make_shared<InlineMath>(node));
+        ast.pushback_child(std::make_shared<InlineMath>(node));
         InlineParser::process(suffix, ast);
     }
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/InlineOverline.hpp
+++ b/src/syntax/InlineOverline.hpp
@@ -1,34 +1,31 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
 
 namespace almo {
 
 struct InlineOverline : public ASTNode {
-  public:
-    InlineOverline() {
-        set_uuid();
-    }
+   public:
+    InlineOverline() { set_uuid(); }
     std::string to_html() const override {
-        return "<span class=\"overline\"> <s>" + concatenated_childs_html() + "</s> </span>";
+        return "<span class=\"overline\"> <s>" + concatenated_childs_html() +
+               "</s> </span>";
     }
 
     std::map<std::string, std::string> get_properties() const override {
-        return {
-        };
+        return {};
     }
-    std::string get_classname() const override {
-        return "InlineOverline";
-    }
+    std::string get_classname() const override { return "InlineOverline"; }
 };
 
 struct InlineOverlineSyntax : public InlineSyntax {
-    static inline const std::regex rex = std::regex(R"((.*?)\~\~(.*?)\~\~(.*))");
+    static inline const std::regex rex =
+        std::regex(R"((.*?)\~\~(.*?)\~\~(.*))");
     int operator()(const std::string &str) const override {
         std::smatch sm;
-        if (std::regex_search(str, sm, rex)){
+        if (std::regex_search(str, sm, rex)) {
             return sm.position(2) - 2;
         }
         return std::numeric_limits<int>::max();
@@ -42,9 +39,9 @@ struct InlineOverlineSyntax : public InlineSyntax {
         InlineParser::process(prefix, ast);
         InlineOverline node;
         InlineParser::process(content, node);
-        ast.add_child(std::make_shared<InlineOverline>(node));
+        ast.pushback_child(std::make_shared<InlineOverline>(node));
         InlineParser::process(suffix, ast);
     }
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/InlineStrong.hpp
+++ b/src/syntax/InlineStrong.hpp
@@ -1,35 +1,32 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
 
 namespace almo {
 
 struct InlineStrong : public ASTNode {
-  public:
-    InlineStrong() {
-        set_uuid();
-    }
+   public:
+    InlineStrong() { set_uuid(); }
 
     std::string to_html() const override {
-        return "<span class=\"strong\"> <strong>" + concatenated_childs_html() + "</strong> </span>";
+        return "<span class=\"strong\"> <strong>" + concatenated_childs_html() +
+               "</strong> </span>";
     }
 
     std::map<std::string, std::string> get_properties() const override {
-        return {
-        };
+        return {};
     }
-    std::string get_classname() const override {
-        return "InlineStrong";
-    }
+    std::string get_classname() const override { return "InlineStrong"; }
 };
 
 struct InlineStrongSyntax : public InlineSyntax {
-    static inline const std::regex rex = std::regex(R"((.*?)\*\*(.*?)\*\*(.*))");
+    static inline const std::regex rex =
+        std::regex(R"((.*?)\*\*(.*?)\*\*(.*))");
     int operator()(const std::string &str) const override {
         std::smatch sm;
-        if (std::regex_search(str, sm, rex)){
+        if (std::regex_search(str, sm, rex)) {
             return sm.position(2) - 2;
         }
         return std::numeric_limits<int>::max();
@@ -43,9 +40,9 @@ struct InlineStrongSyntax : public InlineSyntax {
         InlineParser::process(prefix, ast);
         InlineStrong node;
         InlineParser::process(content, node);
-        ast.add_child(std::make_shared<InlineStrong>(node));
+        ast.pushback_child(std::make_shared<InlineStrong>(node));
         InlineParser::process(suffix, ast);
     }
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/InlineUrl.hpp
+++ b/src/syntax/InlineUrl.hpp
@@ -1,18 +1,18 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
-#include"../utils.hpp"
-
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
+#include "../utils.hpp"
 
 namespace almo {
 
 struct InlineUrl : public ASTNode {
-  private:
+   private:
     std::string url;
     std::string alt;
-  public:
+
+   public:
     InlineUrl(std::string url, std::string alt) : url(url), alt(alt) {
         set_uuid();
     }
@@ -22,21 +22,17 @@ struct InlineUrl : public ASTNode {
     }
 
     std::map<std::string, std::string> get_properties() const override {
-        return {
-            {"url", url},
-            {"alt", alt}
-        };
+        return {{"url", url}, {"alt", alt}};
     }
-    std::string get_classname() const override {
-        return "InlineUrl";
-    }
+    std::string get_classname() const override { return "InlineUrl"; }
 };
 
 struct InlineUrlSyntax : public InlineSyntax {
-    static inline const std::regex rex = std::regex(R"((.*?)\[(.*?)\]\((.*?)\)(.*))");
+    static inline const std::regex rex =
+        std::regex(R"((.*?)\[(.*?)\]\((.*?)\)(.*))");
     int operator()(const std::string &str) const override {
         std::smatch sm;
-        if (std::regex_search(str, sm, rex)){
+        if (std::regex_search(str, sm, rex)) {
             return sm.position(2) - 1;
         }
         return std::numeric_limits<int>::max();
@@ -50,9 +46,9 @@ struct InlineUrlSyntax : public InlineSyntax {
         std::string suffix = sm.format("$4");
         InlineParser::process(prefix, ast);
         InlineUrl node(url, alt);
-        ast.add_child(std::make_shared<InlineUrl>(node));
+        ast.pushback_child(std::make_shared<InlineUrl>(node));
         InlineParser::process(suffix, ast);
     }
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/Item.hpp
+++ b/src/syntax/Item.hpp
@@ -1,30 +1,25 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
-#include"../utils.hpp"
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
+#include "../utils.hpp"
 
 namespace almo {
 
 // 箇条書きの要素を表すクラス
 struct Item : public ASTNode {
-  public:
-    Item() {
-        set_uuid();
-    }
+   public:
+    Item() { set_uuid(); }
 
     std::string to_html() const override {
         return "<li>" + concatenated_childs_html() + "</li>";
     }
 
     std::map<std::string, std::string> get_properties() const override {
-        return {
-        };
+        return {};
     }
-    std::string get_classname() const override {
-        return "Item";
-    }
+    std::string get_classname() const override { return "Item"; }
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/Judge.hpp
+++ b/src/syntax/Judge.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
-#include"../utils.hpp"
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
+#include "../utils.hpp"
 
 namespace almo {
 
 struct Judge : public ASTNode {
-  private:
+   private:
     // 問題のタイトル
     std::string title;
 
@@ -18,8 +18,9 @@ struct Judge : public ASTNode {
     // サンプル出力(単一ファイルのパス)
     std::string sample_out_path;
 
-    // ジャッジの種類. 誤差ジャッジ (err_{rate}) または 完全一致ジャッジ (equal) が指定される.
-    // C++側では特に処理は変わらず、 JS側に `judge_type[uuid]` を指定することで伝えれば切り替わる。
+    // ジャッジの種類. 誤差ジャッジ (err_{rate}) または 完全一致ジャッジ (equal)
+    // が指定される. C++側では特に処理は変わらず、 JS側に `judge_type[uuid]`
+    // を指定することで伝えれば切り替わる。
     std::string judge_type;
 
     // エディタにデフォルトで入力されてあるコード。
@@ -33,26 +34,25 @@ struct Judge : public ASTNode {
 
     // エディタのテーマ
     std::string editor_theme;
-  public:
-    Judge(std::string title, 
-          std::string sample_in_path, 
-          std::string sample_out_path, 
-          std::string in_files_glob, 
-          std::string out_files_glob, 
-          std::string judge_type, 
-          std::string source, 
-          std::string editor_theme) : 
-          title(title), 
-          sample_in_path(sample_in_path), 
-          sample_out_path(sample_out_path), 
-          in_files_glob(in_files_glob), 
-          out_files_glob(out_files_glob), 
-          judge_type(judge_type), 
-          source(source), 
+
+   public:
+    Judge(std::string title, std::string sample_in_path,
+          std::string sample_out_path, std::string in_files_glob,
+          std::string out_files_glob, std::string judge_type,
+          std::string source, std::string editor_theme)
+        : title(title),
+          sample_in_path(sample_in_path),
+          sample_out_path(sample_out_path),
+          in_files_glob(in_files_glob),
+          out_files_glob(out_files_glob),
+          judge_type(judge_type),
+          source(source),
           editor_theme(editor_theme) {
         // ジャッジが`err_{rate}` または `equal` 以外の場合はエラーを出す.
         if (judge_type.substr(0, 4) != "err_" && judge_type != "equal") {
-            throw ParseError("Invalid judge type. Expected `err_{rate}` or `equal`, but `" + judge_type + "` is given.");
+            throw ParseError(
+                "Invalid judge type. Expected `err_{rate}` or `equal`, but `" +
+                judge_type + "` is given.");
         }
         set_uuid();
     }
@@ -60,23 +60,29 @@ struct Judge : public ASTNode {
     std::string to_html() const override {
         std::string uuid_str = get_uuid_str();
 
-
         // タイトルを作る
         std::string title_h3 =
-            "<h3 class=\"problem_title\"> <div class='badge' id='" + uuid_str + "_status'>WJ</div>   " + title + " </h2>\n";
+            "<h3 class=\"problem_title\"> <div class='badge' id='" + uuid_str +
+            "_status'>WJ</div>   " + title + " </h2>\n";
 
         // ここから ace editor を作る.
         // まず editor を入れる用の div を作る.
-        std::string editor_div = "<div class=\"editor\" id=\"" + uuid_str + "\" rows=\"3\" cols=\"80\"></div> \n";
+        std::string editor_div = "<div class=\"editor\" id=\"" + uuid_str +
+                                 "\" rows=\"3\" cols=\"80\"></div> \n";
 
         // ace editor の設定をする.
 
         std::string source_code = join(read_file(source), "\n");
 
-        std::string ace_editor = ""
+        std::string ace_editor =
+            ""
             "<script>"
-            "editor = ace.edit(\"" + uuid_str + "\"); "
-            "editor.setTheme(\"" + editor_theme + "\");"
+            "editor = ace.edit(\"" +
+            uuid_str +
+            "\"); "
+            "editor.setTheme(\"" +
+            editor_theme +
+            "\");"
             "editor.session.setMode(\"ace/mode/python\");"
             "editor.setShowPrintMargin(false);"
             "editor.setHighlightActiveLine(false);"
@@ -89,7 +95,9 @@ struct Judge : public ASTNode {
             "    fontSize: \"14px\""
             "});"
             "editor.renderer.setScrollMargin(10, 10);"
-            "editor.setValue(`" + source_code + "`, -1);"
+            "editor.setValue(`" +
+            source_code +
+            "`, -1);"
             "</script>\n";
 
         // サンプル入力を読み込む.
@@ -99,81 +107,103 @@ struct Judge : public ASTNode {
         // サンプル入力と出力を表示する用の div を作る.
         std::string sample_in_area =
             "<div class=\"box-title\"> サンプルの入力 </div>"
-            "<pre class=\"sample_in\" id=\"" + uuid_str + "_sample_in\">" + sample_in + "</pre>\n";
+            "<pre class=\"sample_in\" id=\"" +
+            uuid_str + "_sample_in\">" + sample_in + "</pre>\n";
 
         std::string sample_out_area =
             "<div class=\"box-title\"> 出力 </div>"
-            "<pre class=\"sample_out\" id=\"" + uuid_str + "_out\"></pre>\n";
+            "<pre class=\"sample_out\" id=\"" +
+            uuid_str + "_out\"></pre>\n";
 
         std::string expect_out_area =
             "<div class=\"box-title\"> サンプルの答え </div>"
-            "<pre class=\"expect_out\" id=\"" + uuid_str + "_expect_out\">" + sample_out + "</pre>\n";
+            "<pre class=\"expect_out\" id=\"" +
+            uuid_str + "_expect_out\">" + sample_out + "</pre>\n";
 
-        // データを定義する。 all_input, all_output, all_sample_input, all_sample_output, problem_status は JS側で使うために定義する.
+        // データを定義する。 all_input, all_output, all_sample_input,
+        // all_sample_output, problem_status は JS側で使うために定義する.
         // また、目次生成のために page_contents にも追加する.
         std::string define_data =
             "<script>"
-            "all_input[\"" + uuid_str + "\"] = [];\n"
-            "all_output[\"" + uuid_str + "\"] = [];\n"
-            "all_sample_input[\"" + uuid_str + "\"] = `" + sample_in + "`;\n"
-            "all_sample_output[\"" + uuid_str + "\"] = `" + sample_out + "`;\n"
-            "problem_status[\"" + uuid_str + "\"] = \"WJ\";\n"
+            "all_input[\"" +
+            uuid_str +
+            "\"] = [];\n"
+            "all_output[\"" +
+            uuid_str +
+            "\"] = [];\n"
+            "all_sample_input[\"" +
+            uuid_str + "\"] = `" + sample_in +
+            "`;\n"
+            "all_sample_output[\"" +
+            uuid_str + "\"] = `" + sample_out +
+            "`;\n"
+            "problem_status[\"" +
+            uuid_str +
+            "\"] = \"WJ\";\n"
             "page_contents.push({\n"
             "    \"type\":\"Problem\",\n"
-            "    \"id\":\"" + uuid_str + "\",\n"
-            "    \"title\":\"" + title + "\"\n"
+            "    \"id\":\"" +
+            uuid_str +
+            "\",\n"
+            "    \"title\":\"" +
+            title +
+            "\"\n"
             "});\n";
 
-        // サンプル入力と出力のファイルの一覧を取得して、それぞれのデータを all_input, all_output に追加する.
+        // サンプル入力と出力のファイルの一覧を取得して、それぞれのデータを
+        // all_input, all_output に追加する.
         std::vector<std::string> in_files = glob(in_files_glob);
         std::vector<std::string> out_files = glob(out_files_glob);
 
-
         for (std::string in_file : in_files) {
             std::string input = join(read_file(in_file));
-            define_data += "\n all_input[\"" + uuid_str + "\"].push(`" + input + "`)";
+            define_data +=
+                "\n all_input[\"" + uuid_str + "\"].push(`" + input + "`)";
         }
 
         for (std::string out_file : out_files) {
             std::string output = join(read_file(out_file));
-            define_data += "\n all_output[\"" + uuid_str + "\"].push(`" + output + "`)";
+            define_data +=
+                "\n all_output[\"" + uuid_str + "\"].push(`" + output + "`)";
         }
 
         define_data += "</script> \n";
 
         // テスト実行ボタンと提出ボタンを作る.
         std::string test_run_button =
-            "<button class=\"runbutton\" onclick=\"runCode('" + uuid_str + "', false)\"> Run Sample </button>\n";
+            "<button class=\"runbutton\" onclick=\"runCode('" + uuid_str +
+            "', false)\"> Run Sample </button>\n";
 
         std::string submit_button =
-            "<button class=\"submitbutton\" onclick=\"runCode('" + uuid_str + "', true)\"> Submit </button>\n";
+            "<button class=\"submitbutton\" onclick=\"runCode('" + uuid_str +
+            "', true)\"> Submit </button>\n";
 
         // ジャッジの種類を JS側に伝えるためのコードを作る.
         std::string judge_code =
             "<script>\n"
-            "judge_types[\"" + uuid_str + "\"] = `" + judge_type + "`\n"
+            "judge_types[\"" +
+            uuid_str + "\"] = `" + judge_type +
+            "`\n"
             "</script>\n";
 
-
-        std::string output = title_h3 + editor_div + ace_editor + sample_in_area + sample_out_area + expect_out_area + define_data + test_run_button + submit_button + judge_code;
+        std::string output = title_h3 + editor_div + ace_editor +
+                             sample_in_area + sample_out_area +
+                             expect_out_area + define_data + test_run_button +
+                             submit_button + judge_code;
 
         return output;
     }
 
     std::map<std::string, std::string> get_properties() const override {
-        return {
-            {"title", title},
-            {"sample_in_path", sample_in_path},
-            {"sample_out_path", sample_out_path},
-            {"in_files_glob", in_files_glob},
-            {"out_files_glob", out_files_glob},
-            {"judge_type", judge_type},
-            {"source", source}
-        };
+        return {{"title", title},
+                {"sample_in_path", sample_in_path},
+                {"sample_out_path", sample_out_path},
+                {"in_files_glob", in_files_glob},
+                {"out_files_glob", out_files_glob},
+                {"judge_type", judge_type},
+                {"source", source}};
     }
-    std::string get_classname() const override {
-        return "Judge";
-    }
+    std::string get_classname() const override { return "Judge"; }
 };
 
 struct JudgeSyntax : BlockSyntax {
@@ -188,33 +218,29 @@ struct JudgeSyntax : BlockSyntax {
         std::map<std::string, std::string> judge_info;
 
         const std::vector<std::string> required_args = {
-            "title",
-            "sample_in",
-            "sample_out",
-            "in",
-            "out",
+            "title", "sample_in", "sample_out", "in", "out",
         };
 
         std::map<std::string, std::string> optional_args = {
-            { "judge", "equal" },
-            { "source", "" },
+            {"judge", "equal"},
+            {"source", ""},
         };
 
         // skip :::judge
         read.move_next_line();
 
-        while (!read.is_eof()){
-            if (rtrim(read.get_row()) == ":::"){
+        while (!read.is_eof()) {
+            if (rtrim(read.get_row()) == ":::") {
                 read.move_next_line();
                 break;
             }
             std::size_t mid = read.get_row().find("=");
-            if (mid == std::string::npos){
+            if (mid == std::string::npos) {
                 throw SyntaxError("judge option must be separated with '='");
             }
             std::string key = rtrim(read.get_row().substr(0u, mid));
-            std::string value = rtrim(ltrim(read.get_row().substr(mid+1)));
-            if (judge_info.contains(key)){
+            std::string value = rtrim(ltrim(read.get_row().substr(mid + 1)));
+            if (judge_info.contains(key)) {
                 throw SyntaxError("Duplicate judge options : " + key);
             }
             judge_info[key] = value;
@@ -222,37 +248,33 @@ struct JudgeSyntax : BlockSyntax {
         }
 
         // required args check
-        for (std::string arg : required_args){
+        for (std::string arg : required_args) {
             if (judge_info.contains(arg)) continue;
             // lost args
             // set title
-            if (judge_info.contains("title")){
-                throw SyntaxError("問題" + judge_info["title"] + "の引数 " + arg + " がありません. 引数を追加してください.");
-            }
-            else {
-                throw SyntaxError("問題タイトルがありません. 引数を追加してください.");
+            if (judge_info.contains("title")) {
+                throw SyntaxError("問題" + judge_info["title"] + "の引数 " +
+                                  arg +
+                                  " がありません. 引数を追加してください.");
+            } else {
+                throw SyntaxError(
+                    "問題タイトルがありません. 引数を追加してください.");
             }
         }
 
         // optional args check
-        for (auto [arg, default_value] : optional_args){
+        for (auto [arg, default_value] : optional_args) {
             if (judge_info.contains(arg)) continue;
             judge_info[arg] = default_value;
         }
 
-        Judge node(
-            judge_info["title"],
-            judge_info["sample_in"],
-            judge_info["sample_out"],
-            judge_info["in"],
-            judge_info["out"],
-            judge_info["judge"],
-            judge_info["source"],
-            "{{ editor_theme }}"
-        );
+        Judge node(judge_info["title"], judge_info["sample_in"],
+                   judge_info["sample_out"], judge_info["in"],
+                   judge_info["out"], judge_info["judge"], judge_info["source"],
+                   "{{ editor_theme }}");
 
-        ast.add_child(std::make_shared<Judge>(node));
+        ast.pushback_child(std::make_shared<Judge>(node));
     }
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/LoadLib.hpp
+++ b/src/syntax/LoadLib.hpp
@@ -1,21 +1,20 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
-#include"../utils.hpp"
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
+#include "../utils.hpp"
 
 namespace almo {
 
-// ライブラリの読み込みをする独自記法. 
+// ライブラリの読み込みをする独自記法.
 struct LoadLib : public ASTNode {
-  private:
+   private:
     // 読み込むライブラリの名前のリスト
     std::vector<std::string> libs;
-  public:
-    LoadLib(std::vector<std::string> libs) : libs(libs) {
-        set_uuid();
-    }
+
+   public:
+    LoadLib(std::vector<std::string> libs) : libs(libs) { set_uuid(); }
 
     // use_libs に追加しておくと JS側で読み込み処理を行う。
     std::string to_html() const override {
@@ -27,13 +26,9 @@ struct LoadLib : public ASTNode {
     };
 
     std::map<std::string, std::string> get_properties() const override {
-        return {
-            {"libs", join(libs)}
-        };
+        return {{"libs", join(libs)}};
     }
-    std::string get_classname() const override {
-        return "LoadLib";
-    }
+    std::string get_classname() const override { return "LoadLib"; }
 };
 
 struct LoadLibSyntax : public BlockSyntax {
@@ -48,12 +43,12 @@ struct LoadLibSyntax : public BlockSyntax {
         // skip :::loadlib
         read.move_next_line();
 
-        if (read.is_eof()){
+        if (read.is_eof()) {
             throw SyntaxError("Empty Library");
         }
 
-        while (!read.is_eof()){
-            if (rtrim(read.get_row()) == ":::"){
+        while (!read.is_eof()) {
+            if (rtrim(read.get_row()) == ":::") {
                 read.move_next_line();
                 break;
             }
@@ -62,8 +57,8 @@ struct LoadLibSyntax : public BlockSyntax {
         }
 
         LoadLib node(libs);
-        ast.add_child(std::make_shared<LoadLib>(node));
+        ast.pushback_child(std::make_shared<LoadLib>(node));
     }
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/Markdown.hpp
+++ b/src/syntax/Markdown.hpp
@@ -1,35 +1,28 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
 
 namespace almo {
 
 struct Markdown : public ASTNode {
-  public:
-    Markdown () {
-        set_uuid();
-    }
+   public:
+    Markdown() { set_uuid(); }
 
-    std::string to_html() const override {
-        return concatenated_childs_html();
-    }
+    std::string to_html() const override { return concatenated_childs_html(); }
 
     std::map<std::string, std::string> get_properties() const override {
-        return {
-        };
+        return {};
     }
-    std::string get_classname() const override {
-        return "Markdown";
-    }
+    std::string get_classname() const override { return "Markdown"; }
 
     std::string to_dot() const {
         std::string childs_dot = concatenated_childs_dot();
-        std::string dot = "digraph G {\n graph [labelloc=\"t\"; \n ]\n" + childs_dot + "}";
+        std::string dot =
+            "digraph G {\n graph [labelloc=\"t\"; \n ]\n" + childs_dot + "}";
         return dot;
     }
-
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/Markdown.hpp
+++ b/src/syntax/Markdown.hpp
@@ -23,6 +23,13 @@ struct Markdown : public ASTNode {
     std::string get_classname() const override {
         return "Markdown";
     }
+
+    std::string to_dot() const {
+        std::string childs_dot = concatenated_childs_dot();
+        std::string dot = "digraph G {\n graph [labelloc=\"t\"; \n ]\n" + childs_dot + "}";
+        return dot;
+    }
+
 };
 
 } // namespace almo

--- a/src/syntax/MathBlock.hpp
+++ b/src/syntax/MathBlock.hpp
@@ -1,36 +1,32 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
-#include"../utils.hpp"
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
+#include "../utils.hpp"
 
 namespace almo {
 
-// 数式ブロック. 内容はMathJaxでレンダリングされる. 内容は `math-block` というクラスが付与されたdivタグで囲まれる
+// 数式ブロック. 内容はMathJaxでレンダリングされる. 内容は `math-block`
+// というクラスが付与されたdivタグで囲まれる
 struct MathBlock : public ASTNode {
-  private:
+   private:
     // markdownで渡された式をそのまま string で持つ。
     std::string expression;
 
-  public:
-    MathBlock(std::string expression) : expression(expression) {
-        set_uuid();
-    }
+   public:
+    MathBlock(std::string expression) : expression(expression) { set_uuid(); }
 
     // mathjax の　複数行数式用に \[ \] で囲む
     std::string to_html() const override {
-        return "<div class=\"math-block\"> \\[ \n" + expression + "\n \\] </div>";
+        return "<div class=\"math-block\"> \\[ \n" + expression +
+               "\n \\] </div>";
     }
 
     std::map<std::string, std::string> get_properties() const override {
-        return {
-            {"expression", expression}
-        };
+        return {{"expression", expression}};
     }
-    std::string get_classname() const override {
-        return "MathBlock";
-    }
+    std::string get_classname() const override { return "MathBlock"; }
 };
 
 struct MathBlockSyntax : public BlockSyntax {
@@ -41,17 +37,17 @@ struct MathBlockSyntax : public BlockSyntax {
     void operator()(Reader &read, ASTNode &ast) const override {
         // BEGIN : '$$.*'
         // END   : '.*$$\s*'
-        // note  : The mathematical rendering library is responsible for 
+        // note  : The mathematical rendering library is responsible for
         //         the treatment of newlines and whitespace.
 
         std::string expression = "";
 
         read.move_next_char(2);
 
-        while (!read.is_eof()){
-            if (rtrim(read.get_rest_row()).ends_with("$$")){
+        while (!read.is_eof()) {
+            if (rtrim(read.get_rest_row()).ends_with("$$")) {
                 std::string tail = rtrim(read.get_rest_row());
-                expression += tail.substr(0,tail.size()-2u);
+                expression += tail.substr(0, tail.size() - 2u);
                 read.move_next_line();
                 break;
             }
@@ -60,8 +56,8 @@ struct MathBlockSyntax : public BlockSyntax {
         }
 
         MathBlock node(expression);
-        ast.add_child(std::make_shared<MathBlock>(node));
+        ast.pushback_child(std::make_shared<MathBlock>(node));
     }
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/NewLine.hpp
+++ b/src/syntax/NewLine.hpp
@@ -1,29 +1,22 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
-#include"../utils.hpp"
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
+#include "../utils.hpp"
 
 namespace almo {
 
 struct NewLine : public ASTNode {
-  public:
-    NewLine () {
-        set_uuid();
-    }
+   public:
+    NewLine() { set_uuid(); }
 
-    std::string to_html() const override {
-        return "<br>";
-    }
+    std::string to_html() const override { return "<br>"; }
 
     std::map<std::string, std::string> get_properties() const override {
-        return {
-        };
+        return {};
     }
-    std::string get_classname() const override {
-        return "NewLine";
-    }
+    std::string get_classname() const override { return "NewLine"; }
 };
 
 struct NewLineSyntax : public BlockSyntax {
@@ -34,9 +27,9 @@ struct NewLineSyntax : public BlockSyntax {
     }
     void operator()(Reader &read, ASTNode &ast) const override {
         NewLine node;
-        ast.add_child(std::make_shared<NewLine>(node));
+        ast.pushback_child(std::make_shared<NewLine>(node));
         read.move_next_line();
     }
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/Quote.hpp
+++ b/src/syntax/Quote.hpp
@@ -1,32 +1,26 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
-#include"../utils.hpp"
-
-#include"Markdown.hpp"
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
+#include "../utils.hpp"
+#include "Markdown.hpp"
 
 namespace almo {
 
 // 引用を表すクラス
 struct Quote : public ASTNode {
-  public:
-    Quote() {
-        set_uuid();
-    }
+   public:
+    Quote() { set_uuid(); }
 
     std::string to_html() const override {
         return "<blockquote>" + concatenated_childs_html() + "</blockquote>";
     }
 
     std::map<std::string, std::string> get_properties() const override {
-        return {
-        };
+        return {};
     }
-    std::string get_classname() const override {
-        return "Quote";
-    }
+    std::string get_classname() const override { return "Quote"; }
 };
 
 struct QuoteSyntax : public BlockSyntax {
@@ -39,8 +33,8 @@ struct QuoteSyntax : public BlockSyntax {
         // END   : '(?!> ).*'
 
         std::vector<std::string> quote_contents;
-        while (!read.is_eof()){
-            if (read.get_row().starts_with("> ")){
+        while (!read.is_eof()) {
+            if (read.get_row().starts_with("> ")) {
                 quote_contents.emplace_back(read.get_row().substr(2));
                 read.move_next_line();
                 continue;
@@ -53,9 +47,9 @@ struct QuoteSyntax : public BlockSyntax {
         Markdown inner_md;
         MarkdownParser parser(quote_contents);
         parser.process(inner_md);
-        node.add_child(std::make_shared<Markdown>(inner_md));
-        ast.add_child(std::make_shared<Quote>(node));
+        node.pushback_child(std::make_shared<Markdown>(inner_md));
+        ast.pushback_child(std::make_shared<Quote>(node));
     }
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/RawText.hpp
+++ b/src/syntax/RawText.hpp
@@ -1,33 +1,26 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
-
 #include <limits>
+
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
 
 namespace almo {
 
 struct RawText : public ASTNode {
-  private:
+   private:
     std::string content;
-  public:
-    RawText(std::string _content) : content(_content) {
-        set_uuid();
-    }
 
-    std::string to_html() const override {
-        return content;
-    }
+   public:
+    RawText(std::string _content) : content(_content) { set_uuid(); }
+
+    std::string to_html() const override { return content; }
 
     std::map<std::string, std::string> get_properties() const override {
-        return {
-            {"content", content}
-        };
+        return {{"content", content}};
     }
-    std::string get_classname() const override {
-        return "RawText";
-    }
+    std::string get_classname() const override { return "RawText"; }
 };
 
 struct RawTextSyntax : InlineSyntax {
@@ -41,8 +34,8 @@ struct RawTextSyntax : InlineSyntax {
     }
     void operator()(const std::string &str, ASTNode &ast) const override {
         RawText node(str);
-        ast.add_child(std::make_shared<RawText>(node));
+        ast.pushback_child(std::make_shared<RawText>(node));
     }
 };
 
-} // namespace almo
+}  // namespace almo

--- a/src/syntax/Table.hpp
+++ b/src/syntax/Table.hpp
@@ -1,18 +1,17 @@
 #pragma once
 
-#include"../interfaces/ast.hpp"
-#include"../interfaces/parse.hpp"
-#include"../interfaces/syntax.hpp"
-#include"../utils.hpp"
-
-#include"Markdown.hpp"
-#include"NewLine.hpp"
-#include"EOF.hpp"
+#include "../interfaces/ast.hpp"
+#include "../interfaces/parse.hpp"
+#include "../interfaces/syntax.hpp"
+#include "../utils.hpp"
+#include "EOF.hpp"
+#include "Markdown.hpp"
+#include "NewLine.hpp"
 
 namespace almo {
 
 struct Table : public ASTNode {
-  private:
+   private:
     std::vector<std::shared_ptr<Markdown>> columns;
     int n_row;
     int n_col;
@@ -21,20 +20,31 @@ struct Table : public ASTNode {
     std::vector<std::string> col_names;
     // 各列について、左寄せ(0), 中央寄せ(1), 右寄せ(2) のいずれかを指定する.
     std::vector<int> col_format;
-  public:
-    Table(std::vector<std::shared_ptr<Markdown>> columns, int n_row, int n_col, std::vector<std::string> col_names, std::vector<int> col_format) : 
-        columns(columns), n_row(n_row), n_col(n_col), col_names(col_names), col_format(col_format) {
+
+   public:
+    Table(std::vector<std::shared_ptr<Markdown>> columns, int n_row, int n_col,
+          std::vector<std::string> col_names, std::vector<int> col_format)
+        : columns(columns),
+          n_row(n_row),
+          n_col(n_col),
+          col_names(col_names),
+          col_format(col_format) {
         set_uuid();
     }
 
-    // テーブル用の特別な to_html. テーブルの to_html でしか呼ばれないので引数が違ってもOK. 
-    std::string to_html(std::vector<std::string> headers_html, std::vector<std::string> childs_html) const {
+    // テーブル用の特別な to_html. テーブルの to_html
+    // でしか呼ばれないので引数が違ってもOK.
+    std::string to_html(std::vector<std::string> headers_html,
+                        std::vector<std::string> childs_html) const {
         std::string output = "<table>\n";
         output += "<thead>\n";
         output += "<tr>\n";
         for (int i = 0; i < n_col; i++) {
-            std::string align = col_format[i] == 0 ? "left" : col_format[i] == 1 ? "center" : "right";
-            output += "<th align=\"" + align + "\">" + headers_html[i] + "</th>\n";
+            std::string align = col_format[i] == 0   ? "left"
+                                : col_format[i] == 1 ? "center"
+                                                     : "right";
+            output +=
+                "<th align=\"" + align + "\">" + headers_html[i] + "</th>\n";
         }
         output += "</tr>\n";
         output += "</thead>\n";
@@ -42,8 +52,11 @@ struct Table : public ASTNode {
         for (int i = 0; i < n_row; i++) {
             output += "<tr>\n";
             for (int j = 0; j < n_col; j++) {
-                std::string align = col_format[j] == 0 ? "left" : col_format[j] == 1 ? "center" : "right";
-                output += "<td align=\"" + align + "\">" + childs_html[i * n_col + j] + "</td>\n";
+                std::string align = col_format[j] == 0   ? "left"
+                                    : col_format[j] == 1 ? "center"
+                                                         : "right";
+                output += "<td align=\"" + align + "\">" +
+                          childs_html[i * n_col + j] + "</td>\n";
             }
             output += "</tr>\n";
         }
@@ -70,7 +83,9 @@ struct Table : public ASTNode {
     std::map<std::string, std::string> get_properties() const override {
         std::string col_format_str = "";
         for (int i = 0; i < n_col; i++) {
-            std::string align = col_format[i] == 0 ? "l" : col_format[i] == 1 ? "c" : "r";
+            std::string align = col_format[i] == 0   ? "l"
+                                : col_format[i] == 1 ? "c"
+                                                     : "r";
             col_format_str += align;
         }
 
@@ -85,22 +100,20 @@ struct Table : public ASTNode {
 
         col_names_str += "]";
 
-        return {
-            {"n_row", std::to_string(n_row)},
-            {"n_col", std::to_string(n_col)},
-            {"col_format", col_format_str},
-            {"col_names", col_names_str}
-        };
+        return {{"n_row", std::to_string(n_row)},
+                {"n_col", std::to_string(n_col)},
+                {"col_format", col_format_str},
+                {"col_names", col_names_str}};
     }
-    std::string get_classname() const override {
-        return "Table";
-    }
+    std::string get_classname() const override { return "Table"; }
 };
 
 struct TableSyntax : public BlockSyntax {
     bool operator()(Reader &read) const override {
         if (!read.is_line_begin()) return false;
-        if (std::regex_match(rtrim(read.get_row()), std::regex(R"((\|[^\|]+).+\|)"))) return true;
+        if (std::regex_match(rtrim(read.get_row()),
+                             std::regex(R"((\|[^\|]+).+\|)")))
+            return true;
         return false;
     }
     void operator()(Reader &read, ASTNode &ast) const override {
@@ -114,7 +127,7 @@ struct TableSyntax : public BlockSyntax {
 
         std::string line = read.get_row();
 
-        while (std::regex_search(line, sm, each_col_regex)){
+        while (std::regex_search(line, sm, each_col_regex)) {
             col_names.push_back(sm[0].str().substr(1));
             line = sm.suffix();
             n_col++;
@@ -130,24 +143,21 @@ struct TableSyntax : public BlockSyntax {
 
         line = read.get_row();
 
-        while (std::regex_search(line, sm, each_col_regex)){
-            if (std::regex_match(sm[0].str(), Lrex)){
+        while (std::regex_search(line, sm, each_col_regex)) {
+            if (std::regex_match(sm[0].str(), Lrex)) {
                 col_format.emplace_back(0);
-            }
-            else if (std::regex_match(sm[0].str(), Crex)){
+            } else if (std::regex_match(sm[0].str(), Crex)) {
                 col_format.emplace_back(1);
-            }
-            else if (std::regex_match(sm[0].str(), Rrex)){
+            } else if (std::regex_match(sm[0].str(), Rrex)) {
                 col_format.emplace_back(2);
-            }
-            else {
+            } else {
                 col_format.emplace_back(0);
             }
 
             line = sm.suffix();
         }
 
-        if (col_names.size() != col_format.size()){
+        if (col_names.size() != col_format.size()) {
             throw SyntaxError("Number of columns of Table must be same");
         }
 
@@ -156,11 +166,11 @@ struct TableSyntax : public BlockSyntax {
         int n_row = 0;
         std::vector<std::string> table;
 
-        while (true){
+        while (true) {
             if (EOFSyntax{}(read) || NewLineSyntax{}(read)) break;
             n_row++;
             line = read.get_row();
-            while (std::regex_search(line, sm, each_col_regex)){
+            while (std::regex_search(line, sm, each_col_regex)) {
                 table.push_back(sm[0].str().substr(1));
                 line = sm.suffix();
             }
@@ -169,7 +179,7 @@ struct TableSyntax : public BlockSyntax {
 
         std::vector<std::shared_ptr<Markdown>> columns_markdowns;
 
-        for (int i = 0; i < n_col; i++){
+        for (int i = 0; i < n_col; i++) {
             Markdown inner_md;
             InlineParser::process(col_names[i], inner_md);
             columns_markdowns.push_back(std::make_shared<Markdown>(inner_md));
@@ -177,14 +187,14 @@ struct TableSyntax : public BlockSyntax {
 
         Table node(columns_markdowns, n_row, n_col, col_names, col_format);
 
-        for (auto cell : table){
+        for (auto cell : table) {
             Markdown inner_md;
             InlineParser::process(cell, inner_md);
-            node.add_child(std::make_shared<Markdown>(inner_md));
+            node.pushback_child(std::make_shared<Markdown>(inner_md));
         }
 
-        ast.add_child(std::make_shared<Table>(node));
+        ast.pushback_child(std::make_shared<Table>(node));
     }
 };
 
-} // namespace almo
+}  // namespace almo


### PR DESCRIPTION
fix #140

ノードの付け替えと必要な AST操作のインターフェースを実装した。

この PR で脚注の実装に必要な全ての機能が実装完了　🎉


```python3
import almo


def pretty_print(ast, indent=0, last=False):
    print("  " * indent + f"{'└──' if last else '├──'} {ast}")
    for i, child in enumerate(ast.childs):
        pretty_print(child, indent + 1, i == len(ast.childs) - 1)


md = """
# Footnote Example

**On my way to the store**[^1], I saw a duck.

[^1]: Oatmeal is better than cereal.

Quack.

"""

ast = almo.parse(md)

print("=== AST ===")


pretty_print(ast)


footnote_defs = ast.nodes_byclass("FootnoteDefinition")


print("=== Move Footnote to the end ===")

ast.pushback_child(
    almo.DivBlock("footnote"),
)

ast.move_node(
    footnote_defs[0],
    ast.childs[-1],
)

pretty_print(ast)
```

```plaintext
=== AST ===
├── <almo.Markdown (uuid: 0)>
  ├── <almo.NewLine (uuid: 1)>
  ├── <almo.Header (uuid: 2)>
    └── <almo.RawText (uuid: 3)>
  ├── <almo.NewLine (uuid: 4)>
  ├── <almo.InlineStrong (uuid: 5)>
    └── <almo.RawText (uuid: 6)>
  ├── <almo.InlineFootnoteReference (uuid: 7)>
  ├── <almo.RawText (uuid: 8)>
  ├── <almo.NewLine (uuid: 9)>
  ├── <almo.FootnoteDefinition (uuid: 10)>
    └── <almo.RawText (uuid: 11)>
  ├── <almo.NewLine (uuid: 12)>
  ├── <almo.RawText (uuid: 13)>
  ├── <almo.NewLine (uuid: 14)>
  └── <almo.NewLine (uuid: 15)>

=== Move Footnote to the end ===
├── <almo.Markdown (uuid: 0)>
  ├── <almo.NewLine (uuid: 1)>
  ├── <almo.Header (uuid: 2)>
    └── <almo.RawText (uuid: 3)>
  ├── <almo.NewLine (uuid: 4)>
  ├── <almo.InlineStrong (uuid: 5)>
    └── <almo.RawText (uuid: 6)>
  ├── <almo.InlineFootnoteReference (uuid: 7)>
  ├── <almo.RawText (uuid: 8)>
  ├── <almo.NewLine (uuid: 9)>
  ├── <almo.NewLine (uuid: 12)>
  ├── <almo.RawText (uuid: 13)>
  ├── <almo.NewLine (uuid: 14)>
  ├── <almo.NewLine (uuid: 15)>
  └── <almo.DivBlock (uuid: 16)>
    └── <almo.FootnoteDefinition (uuid: 10)>
      └── <almo.RawText (uuid: 11)>
```