### PR TITLE
不要な `std::format` の利用を削除

### DIFF
--- a/src/syntax/FootnoteDefinition.hpp
+++ b/src/syntax/FootnoteDefinition.hpp
@@ -17,10 +17,8 @@ struct FootnoteDefinition : public ASTNode {
         std::string label = "label_" + symbol;
         std::string jump_to = "ref_" + symbol;
 
-        return std::format(
-            "<span class=\"footnote-def\" id=\"{}\"><a "
-            "href=\"#{}\">[{}]</a>{}</span>",
-            label, jump_to, symbol, childs_html);
+        return "<span class=\"footnote-def\" id=\"" + label + "\"><a href=\"#" +
+               jump_to + "\">[" + symbol + "]</a>" + childs_html + "</span>";
     }
     std::map<std::string, std::string> get_properties() const override {
         return {{"symbol", symbol}};

--- a/src/syntax/InlineFootnoteReference.hpp
+++ b/src/syntax/InlineFootnoteReference.hpp
@@ -16,16 +16,14 @@ struct InlineFootnoteReference : public ASTNode {
     }
 
     std::string to_html() const override {
-        // This is correct. 
+        // This is correct.
         // `label_` is setted in `FootnoteDefinition` (which we have to jump to)
         std::string label = "ref_" + symbol;
         std::string jump_to = "label_" + symbol;
 
-        return std::format(
-            "<span class=\"footnote-ref\"><sup id=\"{}\"><a "
-            "href=\"#{}\">[{}]</a>"
-            "</sup></span>",
-            label, jump_to, symbol);
+        return "<span class=\"footnote-ref\"><sup id=\"" + label +
+               "\"><a href=\"#" + jump_to + "\">[" + symbol +
+               "]</a></sup></span>";
     }
 
     std::map<std::string, std::string> get_properties() const override {


### PR DESCRIPTION
fix #158 