### PR TITLE
Optimize inline parsing and rendering hot paths

### DIFF
--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -5,6 +5,22 @@
 
 namespace almo {
 
+namespace detail {
+
+inline void collect_nodes_byclass(
+    const ASTNode& node, const std::string& classname,
+    std::vector<std::shared_ptr<ASTNode>>& out) {
+    if (node.get_classname() == classname) {
+        out.push_back(const_cast<ASTNode&>(node).shared_from_this());
+    }
+
+    for (const auto& child : node.childs) {
+        collect_nodes_byclass(*child, classname, out);
+    }
+}
+
+}  // namespace detail
+
 struct uuid_gen_ {
     int operator()() {
         static int uuid = 0;
@@ -120,16 +136,7 @@ std::vector<std::shared_ptr<ASTNode>> ASTNode::get_childs() const {
 std::vector<std::shared_ptr<ASTNode>> ASTNode::nodes_byclass(
     const std::string &classname) const {
     std::vector<std::shared_ptr<ASTNode>> ret;
-    if (get_classname() == classname) {
-        ret.push_back(const_cast<ASTNode *>(this)->shared_from_this());
-    }
-    for (auto child : childs) {
-        std::vector<std::shared_ptr<ASTNode>> childs_ret =
-            child->nodes_byclass(classname);
-        for (auto child_ret : childs_ret) {
-            ret.push_back(child_ret);
-        }
-    }
+    detail::collect_nodes_byclass(*this, classname, ret);
     return ret;
 }
 

--- a/src/interfaces/parse.hpp
+++ b/src/interfaces/parse.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include "../reader.hpp"
 #include "ast.hpp"
 
@@ -9,12 +10,12 @@ namespace almo {
 // parse a line contain only inline syntax
 struct InlineParser {
     template<class Syntax>
-    static void process_inline(const std::string &str, ASTNode &ast, Syntax&& syn, int pos);
+    static void process_inline(std::string_view str, ASTNode &ast, Syntax&& syn, int pos);
 
     template<class Syntax, class HeadSyntax, class... TailSyntax>
-    static void process_inline(const std::string &str, ASTNode &ast, Syntax&& syn, int pos, HeadSyntax&& hsyn, TailSyntax&&... tsyn);
+    static void process_inline(std::string_view str, ASTNode &ast, Syntax&& syn, int pos, HeadSyntax&& hsyn, TailSyntax&&... tsyn);
 
-    static void process(const std::string &str, ASTNode &ast);
+    static void process(std::string_view str, ASTNode &ast);
 };
 
 // parse an entire markdown and detect block syntax

--- a/src/interfaces/syntax.hpp
+++ b/src/interfaces/syntax.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
+#include <limits>
 #include "../reader.hpp"
 #include "ast.hpp"
-#include <regex>
-#include <limits>
+#include <string_view>
 
 namespace almo {
 
@@ -25,11 +25,11 @@ struct InlineSyntax {
     //   ---> substring located at [2,7) detected : '$c+d$'
     //   ---> return 2
     // ( ---> captured substring is located at [3,6) : 'c+d' )
-    virtual int operator()(const std::string &str) const = 0;
+    virtual int operator()(std::string_view str) const = 0;
 
     // update read and ast
     // assume that the string matches as the syntax
-    virtual void operator()(const std::string &str, ASTNode &ast) const = 0;
+    virtual void operator()(std::string_view str, ASTNode &ast) const = 0;
 };
 
 } // namespace almo

--- a/src/parse.hpp
+++ b/src/parse.hpp
@@ -8,13 +8,13 @@
 namespace almo {
 
 template<class Syntax>
-void InlineParser::process_inline(const std::string &str, ASTNode &ast, Syntax&& syn, int pos){
+void InlineParser::process_inline(std::string_view str, ASTNode &ast, Syntax&& syn, int pos){
     std::invoke(syn, str, ast);
 }
 
 // syn has matched at position pos
 template<class Syntax, class HeadSyntax, class... TailSyntax>
-void InlineParser::process_inline(const std::string &str, ASTNode &ast, Syntax&& syn, int pos, HeadSyntax&& hsyn, TailSyntax&&... tsyn){
+void InlineParser::process_inline(std::string_view str, ASTNode &ast, Syntax&& syn, int pos, HeadSyntax&& hsyn, TailSyntax&&... tsyn){
     int newpos = std::invoke(hsyn, str);
     if (newpos < pos){
         // syntax with nearer match detected
@@ -25,8 +25,8 @@ void InlineParser::process_inline(const std::string &str, ASTNode &ast, Syntax&&
     }
 }
 
-void InlineParser::process(const std::string &str, ASTNode &ast){
-    if (str == "") return ;
+void InlineParser::process(std::string_view str, ASTNode &ast){
+    if (str.empty()) return ;
     process_inline(
         str, ast,
         RawTextSyntax{}, std::numeric_limits<int>::max(),

--- a/src/render.hpp
+++ b/src/render.hpp
@@ -4,7 +4,6 @@
 #include <functional>
 #include <iostream>
 #include <map>
-#include <regex>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -13,6 +12,25 @@
 #include "utils.hpp"
 
 namespace almo {
+
+namespace detail {
+
+inline bool has_node_class(const ASTNode& node, const std::string& classname) {
+    if (node.get_classname() == classname) {
+        return true;
+    }
+
+    for (const auto& child : node.childs) {
+        if (has_node_class(*child, classname)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+}  // namespace detail
+
 std::string load_html_template(std::string html_path, std::string css_setting,
                                bool required_pyodide) {
     const std::string pyodide_loader =
@@ -31,15 +49,15 @@ std::string load_html_template(std::string html_path, std::string css_setting,
     std::string result;
     if (css_setting == "light") {
         std::string css = "<style>" + LIGHT_THEME + "</style>";
-        result = std::regex_replace(html, std::regex("\\{\\{style\\}\\}"), css);
+        result = replace_all(html, "{{style}}", css);
     } else if (css_setting == "dark") {
         std::string css = "<style>" + DARK_THEME + "</style>";
-        result = std::regex_replace(html, std::regex("\\{\\{style\\}\\}"), css);
+        result = replace_all(html, "{{style}}", css);
     } else if (css_setting.ends_with(".css")) {
         std::string css =
             "<style>" + join(read_file(css_setting), "\n") + "</style>";
 
-        result = std::regex_replace(html, std::regex("\\{\\{style\\}\\}"), css);
+        result = replace_all(html, "{{style}}", css);
     } else {
         throw InvalidCommandLineArgumentsError(
             "不正なCSSの設定です。 `light`, `dark` もしくは `.css` "
@@ -55,8 +73,7 @@ std::string load_html_template(std::string html_path, std::string css_setting,
         runner = "<!-- Runner is not required. Skip this. -->";
     }
     // runner を挿入
-    result =
-        std::regex_replace(result, std::regex("\\{\\{runner\\}\\}"), runner);
+    result = replace_all(result, "{{runner}}", runner);
 
     return result;
 }
@@ -67,17 +84,13 @@ std::string replace_template(std::string html_template,
     std::string output_html = html_template;
 
     for (auto [key, value] : meta_data) {
-        std::string replace_key = "\\{\\{" + key + "\\}\\}";
-        output_html =
-            std::regex_replace(output_html, std::regex(replace_key), value);
+        output_html = replace_all(output_html, "{{" + key + "}}", value);
     }
 
     std::string syntax_theme = meta_data["syntax_theme"];
 
-    output_html = std::regex_replace(
-        output_html, std::regex("\\{\\{syntax_theme\\}\\}"), syntax_theme);
-    output_html = std::regex_replace(
-        output_html, std::regex("\\{\\{contents\\}\\}"), content);
+    output_html = replace_all(output_html, "{{syntax_theme}}", syntax_theme);
+    output_html = replace_all(output_html, "{{contents}}", content);
 
     return output_html;
 }
@@ -97,11 +110,11 @@ void move_footnote_to_end(Markdown& ast) {
 }
 
 bool required_pyodide(Markdown& ast) {
-    if (ast.nodes_byclass("ExecutableCodeBlock").size() > 0) {
+    if (detail::has_node_class(ast, "ExecutableCodeBlock")) {
         return true;
     }
 
-    if (ast.nodes_byclass("Judge").size() > 0) {
+    if (detail::has_node_class(ast, "Judge")) {
         return true;
     }
 
@@ -109,12 +122,6 @@ bool required_pyodide(Markdown& ast) {
 }
 
 std::string render(Markdown ast, std::map<std::string, std::string> meta_data) {
-    std::vector<std::shared_ptr<ASTNode>> footnote_defs =
-        ast.nodes_byclass("FootnoteDefinition");
-
-    std::shared_ptr<DivBlock> footnote_div =
-        std::make_shared<DivBlock>("footnote");
-
     std::string content = ast.to_html();
 
     std::string html_template =
@@ -185,7 +192,6 @@ ParseSummary md_to_summary(const std::vector<std::string>& md_content,
 
     move_footnote_to_end(ast);
 
-    render(ast, meta_data);
     ParseSummary summary = {
         .ast = ast,
         .html = render(ast, meta_data),

--- a/src/syntax/InlineCodeBlock.hpp
+++ b/src/syntax/InlineCodeBlock.hpp
@@ -4,6 +4,7 @@
 #include "../interfaces/parse.hpp"
 #include "../interfaces/syntax.hpp"
 #include "../utils.hpp"
+#include "inline_match_utils.hpp"
 
 namespace almo {
 
@@ -12,7 +13,7 @@ struct InlineCodeBlock : public ASTNode {
     std::string code;
 
    public:
-    InlineCodeBlock(std::string code) : code(code) { set_uuid(); }
+    InlineCodeBlock(std::string_view code) : code(code) { set_uuid(); }
 
     std::string to_html() const override {
         return "<span class=\"inline-code\"><code>" + escape(code, EscapeFormat::HTML) +
@@ -26,24 +27,20 @@ struct InlineCodeBlock : public ASTNode {
 };
 
 struct InlineCodeBlockSyntax : public InlineSyntax {
-    static inline const std::regex rex = std::regex(R"((.*?)\`(.*?)\`(.*))");
-    int operator()(const std::string &str) const override {
-        std::smatch sm;
-        if (std::regex_search(str, sm, rex)) {
-            return sm.position(2) - 1;
+    int operator()(std::string_view str) const override {
+        inline_match::DelimitedMatch match;
+        if (inline_match::find_delimited(str, "`", "`", match)) {
+            return static_cast<int>(match.start);
         }
         return std::numeric_limits<int>::max();
     }
-    void operator()(const std::string &str, ASTNode &ast) const override {
-        std::smatch sm;
-        std::regex_search(str, sm, rex);
-        std::string prefix = sm.format("$1");
-        std::string code = sm.format("$2");
-        std::string suffix = sm.format("$3");
-        InlineParser::process(prefix, ast);
-        InlineCodeBlock node(code);
+    void operator()(std::string_view str, ASTNode &ast) const override {
+        inline_match::DelimitedMatch match;
+        inline_match::find_delimited(str, "`", "`", match);
+        InlineParser::process(match.prefix, ast);
+        InlineCodeBlock node(match.content);
         ast.pushback_child(std::make_shared<InlineCodeBlock>(node));
-        InlineParser::process(suffix, ast);
+        InlineParser::process(match.suffix, ast);
     }
 };
 

--- a/src/syntax/InlineFootnoteReference.hpp
+++ b/src/syntax/InlineFootnoteReference.hpp
@@ -4,6 +4,7 @@
 #include "../interfaces/parse.hpp"
 #include "../interfaces/syntax.hpp"
 #include "../utils.hpp"
+#include "inline_match_utils.hpp"
 
 namespace almo {
 struct InlineFootnoteReference : public ASTNode {
@@ -11,7 +12,7 @@ struct InlineFootnoteReference : public ASTNode {
     std::string symbol;
 
    public:
-    InlineFootnoteReference(std::string _symbol) : symbol(_symbol) {
+    InlineFootnoteReference(std::string_view _symbol) : symbol(_symbol) {
         set_uuid();
     }
 
@@ -34,24 +35,20 @@ struct InlineFootnoteReference : public ASTNode {
     }
 };
 struct InlineFootnoteReferenceSyntax : public InlineSyntax {
-    static inline const std::regex rex = std::regex(R"((.*?)\[\^(.*?)\](.*))");
-    int operator()(const std::string &str) const override {
-        std::smatch sm;
-        if (std::regex_search(str, sm, rex)) {
-            return sm.position(2) - 1;
+    int operator()(std::string_view str) const override {
+        inline_match::DelimitedMatch match;
+        if (inline_match::find_delimited(str, "[^", "]", match)) {
+            return static_cast<int>(match.start);
         }
         return std::numeric_limits<int>::max();
     }
-    void operator()(const std::string &str, ASTNode &ast) const override {
-        std::smatch sm;
-        std::regex_search(str, sm, rex);
-        std::string prefix = sm.format("$1");
-        std::string symbol = sm.format("$2");
-        std::string suffix = sm.format("$3");
-        InlineParser::process(prefix, ast);
-        InlineFootnoteReference node(symbol);
+    void operator()(std::string_view str, ASTNode &ast) const override {
+        inline_match::DelimitedMatch match;
+        inline_match::find_delimited(str, "[^", "]", match);
+        InlineParser::process(match.prefix, ast);
+        InlineFootnoteReference node(match.content);
         ast.pushback_child(std::make_shared<InlineFootnoteReference>(node));
-        InlineParser::process(suffix, ast);
+        InlineParser::process(match.suffix, ast);
     }
 };
 }  // namespace almo

--- a/src/syntax/InlineImage.hpp
+++ b/src/syntax/InlineImage.hpp
@@ -4,6 +4,7 @@
 #include "../interfaces/parse.hpp"
 #include "../interfaces/syntax.hpp"
 #include "../utils.hpp"
+#include "inline_match_utils.hpp"
 
 namespace almo {
 
@@ -13,7 +14,7 @@ struct InlineImage : public ASTNode {
     std::string caption;
 
    public:
-    InlineImage(std::string url, std::string caption)
+    InlineImage(std::string_view url, std::string_view caption)
         : url(url), caption(caption) {
         set_uuid();
     }
@@ -32,26 +33,20 @@ struct InlineImage : public ASTNode {
 };
 
 struct InlineImageSyntax : public InlineSyntax {
-    static inline const std::regex rex =
-        std::regex(R"((.*?)\!\[(.*?)\]\((.*?)\)(.*))");
-    int operator()(const std::string &str) const override {
-        std::smatch sm;
-        if (std::regex_search(str, sm, rex)) {
-            return sm.position(2) - 2;
+    int operator()(std::string_view str) const override {
+        inline_match::LinkMatch match;
+        if (inline_match::find_link(str, "![", match)) {
+            return static_cast<int>(match.start);
         }
         return std::numeric_limits<int>::max();
     }
-    void operator()(const std::string &str, ASTNode &ast) const override {
-        std::smatch sm;
-        std::regex_search(str, sm, rex);
-        std::string prefix = sm.format("$1");
-        std::string caption = sm.format("$2");
-        std::string url = sm.format("$3");
-        std::string suffix = sm.format("$4");
-        InlineParser::process(prefix, ast);
-        InlineImage node(url, caption);
+    void operator()(std::string_view str, ASTNode &ast) const override {
+        inline_match::LinkMatch match;
+        inline_match::find_link(str, "![", match);
+        InlineParser::process(match.prefix, ast);
+        InlineImage node(match.target, match.label);
         ast.pushback_child(std::make_shared<InlineImage>(node));
-        InlineParser::process(suffix, ast);
+        InlineParser::process(match.suffix, ast);
     }
 };
 

--- a/src/syntax/InlineItalic.hpp
+++ b/src/syntax/InlineItalic.hpp
@@ -3,6 +3,7 @@
 #include "../interfaces/ast.hpp"
 #include "../interfaces/parse.hpp"
 #include "../interfaces/syntax.hpp"
+#include "inline_match_utils.hpp"
 
 namespace almo {
 
@@ -22,25 +23,21 @@ struct InlineItalic : public ASTNode {
 };
 
 struct InlineItalicSyntax : public InlineSyntax {
-    static inline const std::regex rex = std::regex(R"((.*?)\*(.*?)\*(.*))");
-    int operator()(const std::string &str) const override {
-        std::smatch sm;
-        if (std::regex_search(str, sm, rex)) {
-            return sm.position(2) - 1;
+    int operator()(std::string_view str) const override {
+        inline_match::DelimitedMatch match;
+        if (inline_match::find_delimited(str, "*", "*", match)) {
+            return static_cast<int>(match.start);
         }
         return std::numeric_limits<int>::max();
     }
-    void operator()(const std::string &str, ASTNode &ast) const override {
-        std::smatch sm;
-        std::regex_search(str, sm, rex);
-        std::string prefix = sm.format("$1");
-        std::string content = sm.format("$2");
-        std::string suffix = sm.format("$3");
-        InlineParser::process(prefix, ast);
+    void operator()(std::string_view str, ASTNode &ast) const override {
+        inline_match::DelimitedMatch match;
+        inline_match::find_delimited(str, "*", "*", match);
+        InlineParser::process(match.prefix, ast);
         InlineItalic node;
-        InlineParser::process(content, node);
+        InlineParser::process(match.content, node);
         ast.pushback_child(std::make_shared<InlineItalic>(node));
-        InlineParser::process(suffix, ast);
+        InlineParser::process(match.suffix, ast);
     }
 };
 

--- a/src/syntax/InlineMath.hpp
+++ b/src/syntax/InlineMath.hpp
@@ -4,6 +4,7 @@
 #include "../interfaces/parse.hpp"
 #include "../interfaces/syntax.hpp"
 #include "../utils.hpp"
+#include "inline_match_utils.hpp"
 
 namespace almo {
 
@@ -12,7 +13,7 @@ struct InlineMath : public ASTNode {
     std::string expr;
 
    public:
-    InlineMath(std::string _expr) : expr(_expr) { set_uuid(); }
+    InlineMath(std::string_view _expr) : expr(_expr) { set_uuid(); }
 
     // mathjax の　インライン数式用に \( \) で囲む
     std::string to_html() const override {
@@ -26,24 +27,20 @@ struct InlineMath : public ASTNode {
 };
 
 struct InlineMathSyntax : public InlineSyntax {
-    static inline const std::regex rex = std::regex(R"((.*?)\$(.*?)\$(.*))");
-    int operator()(const std::string &str) const override {
-        std::smatch sm;
-        if (std::regex_search(str, sm, rex)) {
-            return sm.position(2) - 1;
+    int operator()(std::string_view str) const override {
+        inline_match::DelimitedMatch match;
+        if (inline_match::find_delimited(str, "$", "$", match)) {
+            return static_cast<int>(match.start);
         }
         return std::numeric_limits<int>::max();
     }
-    void operator()(const std::string &str, ASTNode &ast) const override {
-        std::smatch sm;
-        std::regex_search(str, sm, rex);
-        std::string prefix = sm.format("$1");
-        std::string expr = sm.format("$2");
-        std::string suffix = sm.format("$3");
-        InlineParser::process(prefix, ast);
-        InlineMath node(expr);
+    void operator()(std::string_view str, ASTNode &ast) const override {
+        inline_match::DelimitedMatch match;
+        inline_match::find_delimited(str, "$", "$", match);
+        InlineParser::process(match.prefix, ast);
+        InlineMath node(match.content);
         ast.pushback_child(std::make_shared<InlineMath>(node));
-        InlineParser::process(suffix, ast);
+        InlineParser::process(match.suffix, ast);
     }
 };
 

--- a/src/syntax/InlineOverline.hpp
+++ b/src/syntax/InlineOverline.hpp
@@ -3,6 +3,7 @@
 #include "../interfaces/ast.hpp"
 #include "../interfaces/parse.hpp"
 #include "../interfaces/syntax.hpp"
+#include "inline_match_utils.hpp"
 
 namespace almo {
 
@@ -21,26 +22,21 @@ struct InlineOverline : public ASTNode {
 };
 
 struct InlineOverlineSyntax : public InlineSyntax {
-    static inline const std::regex rex =
-        std::regex(R"((.*?)\~\~(.*?)\~\~(.*))");
-    int operator()(const std::string &str) const override {
-        std::smatch sm;
-        if (std::regex_search(str, sm, rex)) {
-            return sm.position(2) - 2;
+    int operator()(std::string_view str) const override {
+        inline_match::DelimitedMatch match;
+        if (inline_match::find_delimited(str, "~~", "~~", match)) {
+            return static_cast<int>(match.start);
         }
         return std::numeric_limits<int>::max();
     }
-    void operator()(const std::string &str, ASTNode &ast) const override {
-        std::smatch sm;
-        std::regex_search(str, sm, rex);
-        std::string prefix = sm.format("$1");
-        std::string content = sm.format("$2");
-        std::string suffix = sm.format("$3");
-        InlineParser::process(prefix, ast);
+    void operator()(std::string_view str, ASTNode &ast) const override {
+        inline_match::DelimitedMatch match;
+        inline_match::find_delimited(str, "~~", "~~", match);
+        InlineParser::process(match.prefix, ast);
         InlineOverline node;
-        InlineParser::process(content, node);
+        InlineParser::process(match.content, node);
         ast.pushback_child(std::make_shared<InlineOverline>(node));
-        InlineParser::process(suffix, ast);
+        InlineParser::process(match.suffix, ast);
     }
 };
 

--- a/src/syntax/InlineStrong.hpp
+++ b/src/syntax/InlineStrong.hpp
@@ -3,6 +3,7 @@
 #include "../interfaces/ast.hpp"
 #include "../interfaces/parse.hpp"
 #include "../interfaces/syntax.hpp"
+#include "inline_match_utils.hpp"
 
 namespace almo {
 
@@ -22,26 +23,21 @@ struct InlineStrong : public ASTNode {
 };
 
 struct InlineStrongSyntax : public InlineSyntax {
-    static inline const std::regex rex =
-        std::regex(R"((.*?)\*\*(.*?)\*\*(.*))");
-    int operator()(const std::string &str) const override {
-        std::smatch sm;
-        if (std::regex_search(str, sm, rex)) {
-            return sm.position(2) - 2;
+    int operator()(std::string_view str) const override {
+        inline_match::DelimitedMatch match;
+        if (inline_match::find_delimited(str, "**", "**", match)) {
+            return static_cast<int>(match.start);
         }
         return std::numeric_limits<int>::max();
     }
-    void operator()(const std::string &str, ASTNode &ast) const override {
-        std::smatch sm;
-        std::regex_search(str, sm, rex);
-        std::string prefix = sm.format("$1");
-        std::string content = sm.format("$2");
-        std::string suffix = sm.format("$3");
-        InlineParser::process(prefix, ast);
+    void operator()(std::string_view str, ASTNode &ast) const override {
+        inline_match::DelimitedMatch match;
+        inline_match::find_delimited(str, "**", "**", match);
+        InlineParser::process(match.prefix, ast);
         InlineStrong node;
-        InlineParser::process(content, node);
+        InlineParser::process(match.content, node);
         ast.pushback_child(std::make_shared<InlineStrong>(node));
-        InlineParser::process(suffix, ast);
+        InlineParser::process(match.suffix, ast);
     }
 };
 

--- a/src/syntax/InlineUrl.hpp
+++ b/src/syntax/InlineUrl.hpp
@@ -4,6 +4,7 @@
 #include "../interfaces/parse.hpp"
 #include "../interfaces/syntax.hpp"
 #include "../utils.hpp"
+#include "inline_match_utils.hpp"
 
 namespace almo {
 
@@ -13,7 +14,7 @@ struct InlineUrl : public ASTNode {
     std::string alt;
 
    public:
-    InlineUrl(std::string url, std::string alt) : url(url), alt(alt) {
+    InlineUrl(std::string_view url, std::string_view alt) : url(url), alt(alt) {
         set_uuid();
     }
 
@@ -28,26 +29,20 @@ struct InlineUrl : public ASTNode {
 };
 
 struct InlineUrlSyntax : public InlineSyntax {
-    static inline const std::regex rex =
-        std::regex(R"((.*?)\[(.*?)\]\((.*?)\)(.*))");
-    int operator()(const std::string &str) const override {
-        std::smatch sm;
-        if (std::regex_search(str, sm, rex)) {
-            return sm.position(2) - 1;
+    int operator()(std::string_view str) const override {
+        inline_match::LinkMatch match;
+        if (inline_match::find_link(str, "[", match)) {
+            return static_cast<int>(match.start);
         }
         return std::numeric_limits<int>::max();
     }
-    void operator()(const std::string &str, ASTNode &ast) const override {
-        std::smatch sm;
-        std::regex_search(str, sm, rex);
-        std::string prefix = sm.format("$1");
-        std::string alt = sm.format("$2");
-        std::string url = sm.format("$3");
-        std::string suffix = sm.format("$4");
-        InlineParser::process(prefix, ast);
-        InlineUrl node(url, alt);
+    void operator()(std::string_view str, ASTNode &ast) const override {
+        inline_match::LinkMatch match;
+        inline_match::find_link(str, "[", match);
+        InlineParser::process(match.prefix, ast);
+        InlineUrl node(match.target, match.label);
         ast.pushback_child(std::make_shared<InlineUrl>(node));
-        InlineParser::process(suffix, ast);
+        InlineParser::process(match.suffix, ast);
     }
 };
 

--- a/src/syntax/RawText.hpp
+++ b/src/syntax/RawText.hpp
@@ -13,7 +13,7 @@ struct RawText : public ASTNode {
     std::string content;
 
    public:
-    RawText(std::string _content) : content(_content) { set_uuid(); }
+    RawText(std::string_view _content) : content(_content) { set_uuid(); }
 
     std::string to_html() const override { return content; }
 
@@ -29,10 +29,10 @@ struct RawTextSyntax : InlineSyntax {
     // because Rawtext syntax is weakest.
     // If the string matches other Inline syntax
     // RawText does not match it.
-    int operator()(const std::string &str) const override {
+    int operator()(std::string_view str) const override {
         return std::numeric_limits<int>::max();
     }
-    void operator()(const std::string &str, ASTNode &ast) const override {
+    void operator()(std::string_view str, ASTNode &ast) const override {
         RawText node(str);
         ast.pushback_child(std::make_shared<RawText>(node));
     }

--- a/src/syntax/inline_match_utils.hpp
+++ b/src/syntax/inline_match_utils.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <string_view>
+
+namespace almo::inline_match {
+
+struct DelimitedMatch {
+    std::size_t start = std::string_view::npos;
+    std::string_view prefix;
+    std::string_view content;
+    std::string_view suffix;
+};
+
+struct LinkMatch {
+    std::size_t start = std::string_view::npos;
+    std::string_view prefix;
+    std::string_view label;
+    std::string_view target;
+    std::string_view suffix;
+};
+
+inline bool find_delimited(std::string_view str, std::string_view open,
+                           std::string_view close, DelimitedMatch& match) {
+    for (std::size_t open_pos = str.find(open); open_pos != std::string_view::npos;
+         open_pos = str.find(open, open_pos + 1)) {
+        const std::size_t content_start = open_pos + open.size();
+        const std::size_t close_pos = str.find(close, content_start);
+        if (close_pos == std::string_view::npos) {
+            continue;
+        }
+
+        match.start = open_pos;
+        match.prefix = str.substr(0, open_pos);
+        match.content = str.substr(content_start, close_pos - content_start);
+        match.suffix = str.substr(close_pos + close.size());
+        return true;
+    }
+
+    return false;
+}
+
+inline bool find_link(std::string_view str, std::string_view opener,
+                      LinkMatch& match) {
+    for (std::size_t open_pos = str.find(opener); open_pos != std::string_view::npos;
+         open_pos = str.find(opener, open_pos + 1)) {
+        const std::size_t label_start = open_pos + opener.size();
+        const std::size_t separator_pos = str.find("](", label_start);
+        if (separator_pos == std::string_view::npos) {
+            continue;
+        }
+
+        const std::size_t close_pos = str.find(')', separator_pos + 2);
+        if (close_pos == std::string_view::npos) {
+            continue;
+        }
+
+        match.start = open_pos;
+        match.prefix = str.substr(0, open_pos);
+        match.label = str.substr(label_start, separator_pos - label_start);
+        match.target =
+            str.substr(separator_pos + 2, close_pos - (separator_pos + 2));
+        match.suffix = str.substr(close_pos + 1);
+        return true;
+    }
+
+    return false;
+}
+
+}  // namespace almo::inline_match

--- a/src/utils.hpp
+++ b/src/utils.hpp
@@ -10,6 +10,7 @@
 #include <regex>
 #include <sstream>
 #include <string>
+#include <string_view>
 
 // コンパイル時に埋め込む定数
 namespace almo {
@@ -50,6 +51,20 @@ std::string join(std::vector<std::string> v, std::string sep = "") {
         }
     }
     return ss.str();
+}
+
+std::string replace_all(std::string text, std::string_view from,
+                        std::string_view to) {
+    if (from.empty()) {
+        return text;
+    }
+
+    std::size_t pos = 0;
+    while ((pos = text.find(from, pos)) != std::string::npos) {
+        text.replace(pos, from.size(), to);
+        pos += to.size();
+    }
+    return text;
 }
 
 // 文字列を sep で分割する
@@ -223,21 +238,50 @@ std::string escape(const std::string& s, EscapeFormat format = EscapeFormat::JSO
             return o.str();
         }
         case EscapeFormat::HTML: {
-            std::string ret = s;
-            ret = std::regex_replace(ret, std::regex("&"), "&amp;");
-            ret = std::regex_replace(ret, std::regex("<"), "&lt;");
-            ret = std::regex_replace(ret, std::regex(">"), "&gt;");
-            ret = std::regex_replace(ret, std::regex("\""), "&quot;");
-            ret = std::regex_replace(ret, std::regex("'"), "&#39;");
+            std::string ret;
+            ret.reserve(s.size());
+            for (char ch : s) {
+                switch (ch) {
+                    case '&':
+                        ret += "&amp;";
+                        break;
+                    case '<':
+                        ret += "&lt;";
+                        break;
+                    case '>':
+                        ret += "&gt;";
+                        break;
+                    case '"':
+                        ret += "&quot;";
+                        break;
+                    case '\'':
+                        ret += "&#39;";
+                        break;
+                    default:
+                        ret += ch;
+                        break;
+                }
+            }
             return ret;
         }
         case EscapeFormat::DOT: {
-            std::string ret = s;
-            ret = std::regex_replace(ret, std::regex("\\{"), "\\\\{");
-            ret = std::regex_replace(ret, std::regex("\\}"), "\\\\}");
-            ret = std::regex_replace(ret, std::regex("\\|"), "\\\\|");
-            ret = std::regex_replace(ret, std::regex("<"), "\\\\<");
-            ret = std::regex_replace(ret, std::regex(">"), "\\\\>");
+            std::string ret;
+            ret.reserve(s.size());
+            for (char ch : s) {
+                switch (ch) {
+                    case '{':
+                    case '}':
+                    case '|':
+                    case '<':
+                    case '>':
+                        ret += '\\';
+                        ret += ch;
+                        break;
+                    default:
+                        ret += ch;
+                        break;
+                }
+            }
             return ret;
         }
     }


### PR DESCRIPTION
## Summary
- replace regex-heavy inline parsing with string_view-based scanners
- reduce AST traversal and template replacement overhead during render/summary
- keep existing coverage green while cutting the main benchmark hot paths

## Benchmark
Compared with `codex-test-fixtures-structure` using `make bench BENCH_ARGS="--iterations 5 --json --output ..."`:
- ✅ 99.5%% speed up: `parse_inline_heavy_document` (`280.621 ms -> 1.463 ms`)
- ✅ 99.1%% speed up: `parse_large_document` (`144.207 ms -> 1.335 ms`)
- ✅ 96.5%% speed up: `render_large_document` (`163.139 ms -> 5.678 ms`)
- ✅ 88.5%% speed up: `render_table_heavy_document` (`149.835 ms -> 17.299 ms`)
- ✅ 97.7%% speed up: `summary_inline_heavy_document` (`298.085 ms -> 6.790 ms`)
- ✅ 83.3%% speed up: `summary_large_document` (`36.147 ms -> 6.051 ms`)

## Validation
- `make test`
- `make bench BENCH_ARGS='--iterations 5 --json --output /tmp/almo-opt-bench.json'`
