### PR TITLE
Fix benchmark dashboard artifact downloads

### DIFF
--- a/scripts/build_benchmark_dashboard.py
+++ b/scripts/build_benchmark_dashboard.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import argparse
 import io
 import json
@@ -39,6 +41,11 @@ def github_request(url: str, token: str | None) -> dict:
         return json.load(response)
 
 
+class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
 def download_artifact(url: str, token: str | None) -> bytes:
     request = urllib.request.Request(url)
     request.add_header("Accept", "application/vnd.github+json")
@@ -46,7 +53,21 @@ def download_artifact(url: str, token: str | None) -> bytes:
     if token:
         request.add_header("Authorization", f"Bearer {token}")
 
-    with urllib.request.urlopen(request) as response:
+    opener = urllib.request.build_opener(NoRedirectHandler)
+    try:
+        with opener.open(request) as response:
+            return response.read()
+    except urllib.error.HTTPError as error:
+        if error.code not in {301, 302, 303, 307, 308}:
+            raise
+        redirect_url = error.headers.get("Location")
+        if not redirect_url:
+            raise
+
+    # GitHub artifact downloads redirect to a signed object-storage URL.
+    # Sending the GitHub Authorization header there makes the storage request
+    # fail with 401, so follow the signed URL without GitHub API headers.
+    with urllib.request.urlopen(redirect_url) as response:
         return response.read()
 
 


### PR DESCRIPTION
## Summary
- fix benchmark dashboard artifact downloads by handling GitHub artifact redirects explicitly
- avoid sending the GitHub Authorization header to the signed object-storage URL
- allow the dashboard builder to run on local Python 3.9 via postponed annotations

## Cause
The benchmark Pages builder found `dashboard-entry` artifacts, but Python `urllib` followed the artifact download redirect while keeping the GitHub `Authorization` header. The redirected signed storage URL rejected that request with 401, so every CI run was skipped and `dev/bench/dashboard.json` was generated with `entries: []`.

## Validation
- `PYTHONPYCACHEPREFIX=/tmp/almo-pycache python3 -m py_compile scripts/build_benchmark_dashboard.py`
- `python3 scripts/build_benchmark_dashboard.py --repo abap34/almo --out-dir /tmp/almo-dashboard-fixture-mainfix --fixture-json scripts/benchmark_pages/fixture_dashboard.json`
- verified real GitHub artifacts can be fetched: latest 3 CI runs produced `entries=3` with 21 benchmarks each

generated by @codex
